### PR TITLE
fix: runtime singleton initialization race condition

### DIFF
--- a/ak-py/src/agentkernel/core/runtime.py
+++ b/ak-py/src/agentkernel/core/runtime.py
@@ -1,9 +1,11 @@
 import importlib
 import logging
 import traceback
+
 from enum import StrEnum
+from threading import Lock
 from types import ModuleType
-from typing import Any
+from typing import Any, Self
 
 from .base import Agent, Session
 from .config import AKConfig
@@ -20,37 +22,35 @@ class Runtime:
     """
     Runtime class provides the environment for hosting and running agents.
     """
-
-    _log = logging.getLogger("ak.runtime")
-    _instance = None
-    _agents = {}
-    _sessions: SessionStore = None
-    _memory_type: _MemoryType = None
+    _instance: Self  = None
+    _lock: Lock = Lock()
 
     def __init__(self, memory_type: _MemoryType = _MemoryType.IN_MEMORY):
-        Runtime._memory_type = memory_type
-        if Runtime._instance is not None:
-            raise Exception("Runtime is a singleton class")
+        self._log = logging.getLogger("ak.runtime")
+        self._agents = {}
+        self._sessions: SessionStore = None
         if memory_type == _MemoryType.REDIS:
             self._sessions = RedisSessionStore(RedisDriver())
             self._log.info("Using Redis session store")
         else:
-            self._log.info("Using in-memory session store")
             self._sessions = InMemorySessionStore()
-        Runtime._instance = self
+            self._log.info("Using in-memory session store")
 
     @staticmethod
     def instance() -> "Runtime":
         if Runtime._instance is None:
-            env_mem = AKConfig.get().session.type.upper()
-            try:
-                memory_type: _MemoryType = _MemoryType(env_mem) if env_mem else _MemoryType.IN_MEMORY
-            except ValueError:
-                Runtime._log.warning(f"Invalid memory type '{env_mem}', falling back to IN_MEMORY")
-                Runtime._log.warning(traceback.format_exc())
-                memory_type = _MemoryType.IN_MEMORY
-            Runtime._log.debug(f"Using memory type: {memory_type}")
-            Runtime(memory_type)
+            with Runtime._lock:
+                if Runtime._instance is None:
+                    log = logging.getLogger("ak.runtime")
+                    env_mem = AKConfig.get().session.type.upper()
+                    try:
+                        memory_type: _MemoryType = _MemoryType(env_mem) if env_mem else _MemoryType.IN_MEMORY
+                    except ValueError:
+                        log.warning(f"Invalid memory type '{env_mem}', falling back to IN_MEMORY")
+                        log.warning(traceback.format_exc())
+                        memory_type = _MemoryType.IN_MEMORY
+                    log.debug(f"Using memory type: {memory_type}")
+                    Runtime._instance = Runtime(memory_type)
         return Runtime._instance
 
     def load(self, module: str) -> ModuleType:

--- a/ak-py/tests/test_module.py
+++ b/ak-py/tests/test_module.py
@@ -53,9 +53,6 @@ class SimpleModule(Module):
 
 def reset_runtime_singleton():
     Runtime._instance = None
-    Runtime._agents = {}
-    Runtime._sessions = None
-    Runtime._memory_type = None
 
 
 def test_module_add_updates_agents(monkeypatch):

--- a/ak-py/tests/test_runtime.py
+++ b/ak-py/tests/test_runtime.py
@@ -1,7 +1,9 @@
+from agentkernel.core.sessions.in_memory import InMemorySessionStore
+from agentkernel.core.sessions.redis import RedisSessionStore
 import pytest
 
 from agentkernel import Agent, Runner
-from agentkernel.core.runtime import Runtime, _MemoryType
+from agentkernel.core.runtime import Runtime
 
 
 class DummyRunner(Runner):
@@ -34,9 +36,6 @@ class DummyAgent(Agent):
 def reset_runtime_singleton():
     # helper to reset the singleton between tests
     Runtime._instance = None
-    Runtime._agents = {}
-    Runtime._sessions = None
-    Runtime._memory_type = None
 
 
 def test_runtime_instance_redis_when_config(monkeypatch):
@@ -55,7 +54,7 @@ def test_runtime_instance_redis_when_config(monkeypatch):
 
     rt = Runtime.instance()
     # Should select REDIS memory type and initialize a session store
-    assert Runtime._memory_type == _MemoryType.REDIS
+    assert type(rt._sessions) is RedisSessionStore
     assert rt.sessions() is not None
 
 
@@ -69,7 +68,7 @@ def test_runtime_instance_invalid_fallsback(monkeypatch):
     monkeypatch.setattr("agentkernel.core.runtime.AKConfig.get", classmethod(lambda cls: FakeCfg))
 
     rt = Runtime.instance()
-    assert Runtime._memory_type == _MemoryType.IN_MEMORY
+    assert type(rt._sessions) is InMemorySessionStore
     # Should be able to register and list agents
     a = DummyAgent("a1")
     rt.register(a)


### PR DESCRIPTION
This bug fix adds a lock for the singleton instance of the `Runtime`.

It also makes it possible to have multiple `Runtime` instances.

Signed-off-by: Tharindu Dissanayake <td@yaalalabs.com>
