### PR TITLE
fix: openai-dynamodb example dynamodb table creation issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,13 @@
 ## Description
 <!-- Provide a brief description of the changes in this PR -->
+This update resolves a DynamoDB creation issue where the table ARN was unknown at plan time, causing ECS IAM policy attachment to fail.
 
 ## Type of Change
 <!-- Mark the relevant option with an "x" -->
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
+- [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 - [ ] Refactoring (no functional changes)
 - [ ] Performance improvement
@@ -14,41 +15,25 @@
 - [ ] CI/CD update
 - [ ] Other (please describe):
 
-## Related Issues
-<!-- Link to related issues using #issue_number -->
-
-Fixes #
-Relates to #
 
 ## Changes Made
 <!-- List the main changes made in this PR -->
 
-- 
-- 
-- 
+- change [( count = local.dynamodb_memory_table_arn != null ? 1 : 0 ) to ( count = var.create_dynamodb_memory_table == true ? 1 : 0 )]
+- Corrected ECS task IAM policy attachment.
+- Added missing create_tasks_iam_role variable.
 
-## Testing
-<!-- Describe the testing you have performed -->
-
-- [ ] Unit tests pass locally
-- [ ] Integration tests pass locally
-- [ ] Manual testing completed
-- [ ] New tests added for changes
 
 ## Checklist
 <!-- Mark completed items with an "x" -->
 
-- [ ] My code follows the project's style guidelines
-- [ ] I have performed a self-review of my code
+- [x] My code follows the project's style guidelines
+- [x] I have performed a self-review of my code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
+- [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published
 
-## Screenshots (if applicable)
-<!-- Add screenshots to help explain your changes -->
 
-## Additional Notes
-<!-- Add any other context about the PR here -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,12 @@
 ## Description
 <!-- Provide a brief description of the changes in this PR -->
-This update resolves a DynamoDB creation issue where the table ARN was unknown at plan time, causing ECS IAM policy attachment to fail.
 
 ## Type of Change
 <!-- Mark the relevant option with an "x" -->
 
-- [x] Bug fix (non-breaking change which fixes an issue)
+- [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
-- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 - [ ] Refactoring (no functional changes)
 - [ ] Performance improvement
@@ -15,25 +14,41 @@ This update resolves a DynamoDB creation issue where the table ARN was unknown a
 - [ ] CI/CD update
 - [ ] Other (please describe):
 
+## Related Issues
+<!-- Link to related issues using #issue_number -->
+
+Fixes #
+Relates to #
 
 ## Changes Made
 <!-- List the main changes made in this PR -->
 
-- change [( count = local.dynamodb_memory_table_arn != null ? 1 : 0 ) to ( count = var.create_dynamodb_memory_table == true ? 1 : 0 )]
-- Corrected ECS task IAM policy attachment.
-- Added missing create_tasks_iam_role variable.
+- 
+- 
+- 
 
+## Testing
+<!-- Describe the testing you have performed -->
+
+- [ ] Unit tests pass locally
+- [ ] Integration tests pass locally
+- [ ] Manual testing completed
+- [ ] New tests added for changes
 
 ## Checklist
 <!-- Mark completed items with an "x" -->
 
-- [x] My code follows the project's style guidelines
-- [x] I have performed a self-review of my code
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [x] My changes generate no new warnings
+- [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] Any dependent changes have been merged and published
 
+## Screenshots (if applicable)
+<!-- Add screenshots to help explain your changes -->
 
+## Additional Notes
+<!-- Add any other context about the PR here -->

--- a/ak-deployment/ak-aws/containerized/ecs.tf
+++ b/ak-deployment/ak-aws/containerized/ecs.tf
@@ -5,7 +5,7 @@ resource "aws_service_discovery_http_namespace" "this" {
 }
 
 resource "aws_iam_policy" "dynamodb_policy" {
-  count       = local.dynamodb_memory_table_arn != null ? 1 : 0
+  count       = var.create_dynamodb_memory_table == true ? 1 : 0
   name        = "${var.product_alias}-${var.env_alias}-${var.module_name}-dynamodb-policy"
   description = "Policy for DynamoDB access"
 
@@ -74,7 +74,9 @@ module "ecs" {
 
       # Attach DynamoDB access to the task role if a memory table exists
       create_tasks_iam_role   = true
-      tasks_iam_role_policies = local.dynamodb_memory_table_arn != null ? { DynamoDB = aws_iam_policy.dynamodb_policy[0].arn } : {}
+      tasks_iam_role_policies = var.create_tasks_iam_role ? {
+        DynamoDB = var.create_dynamodb_memory_table ? aws_iam_policy.dynamodb_policy[0].arn : null
+      } : {}
 
       container_definitions = {
         (local.container_name) = {

--- a/ak-deployment/ak-aws/containerized/ecs.tf
+++ b/ak-deployment/ak-aws/containerized/ecs.tf
@@ -74,7 +74,7 @@ module "ecs" {
 
       # Attach DynamoDB access to the task role if a memory table exists
       create_tasks_iam_role   = true
-      tasks_iam_role_policies = var.create_tasks_iam_role ? {
+      tasks_iam_role_policies = var.create_dynamodb_memory_table ? {
         DynamoDB = var.create_dynamodb_memory_table ? aws_iam_policy.dynamodb_policy[0].arn : null
       } : {}
 

--- a/ak-deployment/ak-aws/containerized/variables.tf
+++ b/ak-deployment/ak-aws/containerized/variables.tf
@@ -163,5 +163,11 @@ variable "container_type" {
   }
 }
 
+variable "create_tasks_iam_role" {
+  type        = bool
+  description = "Whether to create a tasks IAM role in the ECS service"
+  default     = true
+}
+
 data "aws_ecr_authorization_token" "token" {}
 data "aws_caller_identity" "current" {}

--- a/ak-deployment/ak-aws/containerized/variables.tf
+++ b/ak-deployment/ak-aws/containerized/variables.tf
@@ -163,11 +163,5 @@ variable "container_type" {
   }
 }
 
-variable "create_tasks_iam_role" {
-  type        = bool
-  description = "Whether to create a tasks IAM role in the ECS service"
-  default     = true
-}
-
 data "aws_ecr_authorization_token" "token" {}
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
This update resolves a DynamoDB creation issue where the table ARN was unknown at plan time, causing ECS IAM policy attachment to fail.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] CI/CD update
- [ ] Other (please describe):

## Changes Made
<!-- List the main changes made in this PR -->

- change [( count = local.dynamodb_memory_table_arn != null ? 1 : 0 ) to ( count = var.create_dynamodb_memory_table == true ? 1 : 0 )]
- Corrected ECS task IAM policy attachment.
- Added missing create_tasks_iam_role variable.

## Checklist
<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

