### PR TITLE
fix: GlobalRuntime direct access for auxiliary memory

### DIFF
--- a/ak-py/src/agentkernel/api/a2a/a2a.py
+++ b/ak-py/src/agentkernel/api/a2a/a2a.py
@@ -11,7 +11,7 @@ from a2a.utils.errors import ServerError
 
 from ...core import Agent, AgentService
 from ...core.config import AKConfig
-from ...core.runtime import ModuleLoader
+from ...core.runtime import Runtime
 
 
 class A2A:
@@ -70,7 +70,7 @@ class A2A:
             return
         if not AKConfig.get().a2a.enabled:
             return
-        agents: dict[str, Agent] = ModuleLoader.runtime().agents()
+        agents: dict[str, Agent] = Runtime.current().agents()
         for name, agent in agents.items():
             whitelisted = AKConfig.get().a2a.agents == ["*"] or name in AKConfig.get().a2a.agents
             if not whitelisted:

--- a/ak-py/src/agentkernel/api/a2a/a2a.py
+++ b/ak-py/src/agentkernel/api/a2a/a2a.py
@@ -9,8 +9,9 @@ from a2a.types import AgentCard, InternalError, UnsupportedOperationError
 from a2a.utils import new_agent_text_message
 from a2a.utils.errors import ServerError
 
-from ...core import Agent, AgentService, GlobalRuntime
+from ...core import Agent, AgentService
 from ...core.config import AKConfig
+from ...core.runtime import ModuleLoader
 
 
 class A2A:
@@ -69,7 +70,7 @@ class A2A:
             return
         if not AKConfig.get().a2a.enabled:
             return
-        agents: dict[str, Agent] = GlobalRuntime.instance().agents()
+        agents: dict[str, Agent] = ModuleLoader.runtime().agents()
         for name, agent in agents.items():
             whitelisted = AKConfig.get().a2a.agents == ["*"] or name in AKConfig.get().a2a.agents
             if not whitelisted:

--- a/ak-py/src/agentkernel/api/handler.py
+++ b/ak-py/src/agentkernel/api/handler.py
@@ -17,7 +17,8 @@ from agentkernel.core.model import (
     AgentRequestText,
 )
 
-from ..core import AgentService, Config, GlobalRuntime
+from ..core import AgentService, Config
+from ..core.runtime import ModuleLoader
 
 
 class RESTRequestHandler(ABC):
@@ -37,7 +38,7 @@ class RESTRequestHandler(ABC):
 
         @router.get("/agents")
         def list_agents():
-            return {"agents": list(GlobalRuntime.instance().agents().keys())}
+            return {"agents": list(ModuleLoader.runtime().agents().keys())}
 
         """
         pass
@@ -93,7 +94,7 @@ class AgentRESTRequestHandler(RESTRequestHandler):
 
         @router.get("/agents")
         def list_agents():
-            return {"agents": list(GlobalRuntime.instance().agents().keys())}
+            return {"agents": list(ModuleLoader.runtime().agents().keys())}
 
         @router.post("/run")
         async def run(body: AgentRESTRequestHandler.RunRequest):

--- a/ak-py/src/agentkernel/api/handler.py
+++ b/ak-py/src/agentkernel/api/handler.py
@@ -18,7 +18,7 @@ from agentkernel.core.model import (
 )
 
 from ..core import AgentService, Config
-from ..core.runtime import ModuleLoader
+from ..core.runtime import Runtime
 
 
 class RESTRequestHandler(ABC):
@@ -38,7 +38,8 @@ class RESTRequestHandler(ABC):
 
         @router.get("/agents")
         def list_agents():
-            return {"agents": list(ModuleLoader.runtime().agents().keys())}
+            from ..core.runtime import Runtime
+            return {"agents": list(Runtime.current().agents().keys())}
 
         """
         pass
@@ -94,7 +95,7 @@ class AgentRESTRequestHandler(RESTRequestHandler):
 
         @router.get("/agents")
         def list_agents():
-            return {"agents": list(ModuleLoader.runtime().agents().keys())}
+            return {"agents": list(Runtime.current().agents().keys())}
 
         @router.post("/run")
         async def run(body: AgentRESTRequestHandler.RunRequest):

--- a/ak-py/src/agentkernel/api/mcp/akmcp.py
+++ b/ak-py/src/agentkernel/api/mcp/akmcp.py
@@ -6,7 +6,7 @@ from fastmcp.server.http import StarletteWithLifespan
 
 from ...core import Agent, AgentService
 from ...core.config import AKConfig
-from ...core.runtime import ModuleLoader
+from ...core.runtime import Runtime
 
 
 class MCP:
@@ -61,7 +61,7 @@ class MCP:
         if cls._fastmcp is None:
             cls._fastmcp = FastMCP("Agent Kernel FastMCP Instance")
         if AKConfig.get().mcp.expose_agents:
-            agents: dict[str, Agent] = ModuleLoader.runtime().agents()
+            agents: dict[str, Agent] = Runtime.current().agents()
             for name, agent in agents.items():
                 whitelisted = AKConfig.get().mcp.agents == ["*"] or name in AKConfig.get().mcp.agents
                 if not whitelisted:

--- a/ak-py/src/agentkernel/api/mcp/akmcp.py
+++ b/ak-py/src/agentkernel/api/mcp/akmcp.py
@@ -4,8 +4,9 @@ from typing import Any
 from fastmcp import Context, FastMCP
 from fastmcp.server.http import StarletteWithLifespan
 
-from ...core import Agent, AgentService, GlobalRuntime
+from ...core import Agent, AgentService
 from ...core.config import AKConfig
+from ...core.runtime import ModuleLoader
 
 
 class MCP:
@@ -60,7 +61,7 @@ class MCP:
         if cls._fastmcp is None:
             cls._fastmcp = FastMCP("Agent Kernel FastMCP Instance")
         if AKConfig.get().mcp.expose_agents:
-            agents: dict[str, Agent] = GlobalRuntime.instance().agents()
+            agents: dict[str, Agent] = ModuleLoader.runtime().agents()
             for name, agent in agents.items():
                 whitelisted = AKConfig.get().mcp.agents == ["*"] or name in AKConfig.get().mcp.agents
                 if not whitelisted:

--- a/ak-py/src/agentkernel/core/__init__.py
+++ b/ak-py/src/agentkernel/core/__init__.py
@@ -24,7 +24,7 @@ from .model import (
 )
 from .config import AKConfig as Config
 from .module import Module
-from .runtime import GlobalRuntime, Runtime
+from .runtime import GlobalRuntime, Runtime, AuxiliaryCache
 from .service import AgentService
 from .hooks import PreHook, PostHook
 from .util.key_value_cache import KeyValueCache

--- a/ak-py/src/agentkernel/core/__init__.py
+++ b/ak-py/src/agentkernel/core/__init__.py
@@ -24,7 +24,7 @@ from .model import (
 )
 from .config import AKConfig as Config
 from .module import Module
-from .runtime import GlobalRuntime, Runtime, AuxiliaryCache
+from .runtime import Runtime, AuxiliaryCache
 from .service import AgentService
 from .hooks import PreHook, PostHook
 from .util.key_value_cache import KeyValueCache

--- a/ak-py/src/agentkernel/core/module.py
+++ b/ak-py/src/agentkernel/core/module.py
@@ -3,7 +3,7 @@ from typing import Any, List
 
 from ..core.hooks import PostHook, PreHook
 from .base import Agent
-from .runtime import ModuleLoader
+from .runtime import Runtime
 
 
 class Module(ABC):
@@ -33,7 +33,7 @@ class Module(ABC):
         Unloads and deregisters all agents in the module
         """
         for agent in self._agents:
-            ModuleLoader.runtime().deregister(agent)
+            Runtime.current().deregister(agent)
         self._agents.clear()
 
     def get_agent(self, name: str) -> Agent | None:
@@ -67,7 +67,7 @@ class Module(ABC):
         for agent in agents:
             try:
                 wrapped = self._wrap(agent, agents)
-                ModuleLoader.runtime().register(wrapped)
+                Runtime.current().register(wrapped)
                 registered.append(wrapped)
             except Exception:
                 self._agents = registered

--- a/ak-py/src/agentkernel/core/runtime.py
+++ b/ak-py/src/agentkernel/core/runtime.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import logging
 from threading import RLock
@@ -6,8 +8,7 @@ from typing import Optional
 
 from singleton_type import Singleton
 
-from agentkernel.core.util.key_value_cache import KeyValueCache
-
+from ..core.util.key_value_cache import KeyValueCache
 from .base import Agent, Session
 from .builder import SessionStoreBuilder
 from .model import (
@@ -154,32 +155,6 @@ class Runtime:
         """
         return self._sessions
 
-    def get_volatile_cache(self, session_id: str | None = None) -> KeyValueCache:
-        """
-        Retrieves the volatile key-value cache associated with the provided session.
-        :param session_id: The session to retrieve the volatile cache for. If not provided, the current context is used to find the session
-        :return: The volatile key-value cache.
-        """
-        if session_id is None:
-            session_id = Session.get_current_session_id()
-
-        if session_id is None or session_id == "":
-            raise Exception("No current session context available to retrieve volatile cache.")
-        return self._sessions.load(session_id).get_volatile_cache()
-
-    def get_non_volatile_cache(self, session_id: str | None = None) -> KeyValueCache:
-        """
-        Retrieves the non-volatile key-value cache associated with the provided session.
-        :param session_id: The session to retrieve the non-volatile cache for. If not provided, the current context is used to find the session
-        :return: The non-volatile key-value cache.
-        """
-        if session_id is None:
-            session_id = Session.get_current_session_id()
-
-        if session_id is None or session_id == "":
-            raise Exception("No current session context available to retrieve non-volatile cache.")
-        return self._sessions.load(session_id).get_non_volatile_cache()
-
 
 class GlobalRuntime(Runtime, metaclass=Singleton):
     """
@@ -267,3 +242,39 @@ class ModuleLoader:
         """
         with ModuleLoader._lock, runtime:
             return importlib.import_module(module)
+
+
+class AuxiliaryCache:
+    """
+    AuxiliaryCache provides access to volatile and non-volatile key-value caches associated with
+    the current or a provided session.
+    """
+
+    @staticmethod
+    def get_volatile_cache(session_id: str | None = None) -> KeyValueCache:
+        """
+        Retrieves the volatile key-value cache associated with the provided session.
+        :param session_id: The session to retrieve the volatile cache for. If not provided, the current context is used to find the session
+        :return: The volatile key-value cache.
+        """
+        if session_id is None:
+            session_id = Session.get_current_session_id()
+
+        if session_id is None or session_id == "":
+            raise Exception("No current session context available to retrieve volatile cache.")
+
+        return ModuleLoader.runtime().sessions().load(session_id).get_volatile_cache()
+
+    @staticmethod
+    def get_non_volatile_cache(session_id: str | None = None) -> KeyValueCache:
+        """
+        Retrieves the non-volatile key-value cache associated with the provided session.
+        :param session_id: The session to retrieve the non-volatile cache for. If not provided, the current context is used to find the session
+        :return: The non-volatile key-value cache.
+        """
+        if session_id is None:
+            session_id = Session.get_current_session_id()
+
+        if session_id is None or session_id == "":
+            raise Exception("No current session context available to retrieve non-volatile cache.")
+        return ModuleLoader.runtime().sessions().load(session_id).get_non_volatile_cache()

--- a/ak-py/src/agentkernel/core/runtime.py
+++ b/ak-py/src/agentkernel/core/runtime.py
@@ -29,6 +29,9 @@ class Runtime:
     Runtime class provides the environment for hosting and running agents.
     """
 
+    _current: Optional[Runtime] = None
+    _lock: RLock = RLock()
+
     def __init__(self, sessions: SessionStore):
         """
         Initialize the Runtime.
@@ -39,36 +42,55 @@ class Runtime:
         self._agents = {}
         self._sessions = sessions
 
+    @staticmethod
+    def current() -> Runtime:
+        """
+        Return the currently active Runtime instance. By default this is the
+        global singleton Runtime instance.
+
+        :return: The currently active runtime instance.
+        """
+        return Runtime._current or GlobalRuntime.instance()
+
     def __enter__(self) -> "Runtime":
         """
-        Enter the Runtime context manager and attach the Runtime to the ModuleLoader.
+        Enter the Runtime context manager and set as the current Runtime.
 
-        This method is called when entering a 'with' statement block. It attaches
-        the ModuleLoader to this runtime instance, making it the active runtime
-        context for module loading operations.
+        This method is called when entering a 'with' statement block. It sets
+        this runtime instance as the active runtime context.
 
         :return: The runtime instance itself, allowing it to be used as a context manager in with statements.
         """
-        ModuleLoader.attach(self)
+        with Runtime._lock:
+            if Runtime._current is not None and Runtime._current != self:
+                raise Exception("A different runtime is already active")
+            Runtime._current = self
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """
-        Exit the Runtime context manager and detach from the ModuleLoader.
+        Exit the Runtime context manager and clear the current Runtime.
 
-        This method is called when exiting a 'with' statement block. It detaches
-        the runtime instance from the ModuleLoader, performing necessary cleanup.
+        This method is called when exiting a 'with' statement block. It clears
+        the runtime instance from being the active runtime, performing necessary cleanup.
         """
-        ModuleLoader.detach(self)
+        with Runtime._lock:
+            if Runtime._current is not None and Runtime._current != self:
+                raise Exception("A different runtime is currently active")
+            Runtime._current = None
 
     def load(self, module: str) -> ModuleType:
         """
         Loads an agent module dynamically.
         :param module: Name of the module to load.
         :return: The loaded module.
+
+        :raises ModuleNotFoundError: If the specified module cannot be found.
+        :raises ImportError: If there's an error during the module import process.
         """
         self._log.debug(f"Loading module '{module}'")
-        return ModuleLoader.load(self, module)
+        with self:
+            return importlib.import_module(module)
 
     def agents(self) -> dict[str, Agent]:
         """
@@ -179,71 +201,6 @@ class GlobalRuntime(Runtime, metaclass=Singleton):
         return GlobalRuntime()
 
 
-class ModuleLoader:
-    """
-    ModuleLoader is responsible for loading agent modules dynamically.
-    """
-
-    _runtime: Optional[Runtime] = None
-    _lock: RLock = RLock()
-
-    @staticmethod
-    def runtime() -> Runtime:
-        """
-        Return the Runtime instance set to load the module. By default this is the
-        global singleton Runtime instance.
-        """
-        return ModuleLoader._runtime or GlobalRuntime.instance()
-
-    @staticmethod
-    def attach(runtime: Runtime):
-        """
-        Attach a Runtime instance to the ModuleLoader.
-
-        This method sets the Runtime instance that will be used by the ModuleLoader for
-        loading and managing modules. It ensures thread-safety using a lock and validates
-        that only one Runtime can be attached at a time.
-
-        :param runtime: The Runtime instance to attach to the ModuleLoader.
-        :raises Exception: If a different runtime instance is already attached to the ModuleLoader.
-        """
-        with ModuleLoader._lock:
-            if ModuleLoader._runtime is not None and ModuleLoader._runtime != runtime:
-                raise Exception("A different runtime is already attached")
-            ModuleLoader._runtime = runtime
-
-    @staticmethod
-    def detach(runtime: Runtime):
-        """
-        Detach a Runtime instance from the ModuleLoader.
-
-        This method removes the Runtime association from the ModuleLoader in a thread-safe manner.
-        It validates that the runtime being detached matches the currently attached runtime before
-        proceeding with the detachment.
-
-        :param runtime: The runtime instance to detach from the ModuleLoader.
-        :raises Exception: If a different runtime is currently attached than the one being detached.
-        """
-        with ModuleLoader._lock:
-            if ModuleLoader._runtime is not None and ModuleLoader._runtime != runtime:
-                raise Exception("A different runtime is already attached")
-            ModuleLoader._runtime = None
-
-    @staticmethod
-    def load(runtime: Runtime, module: str) -> ModuleType:
-        """
-        Load a module within the context of a given runtime.
-        :param runtime: The runtime environment to be associated with the module loading process.
-        :param module: The name of the module to import (e.g., 'os.path' or 'mypackage.mymodule').
-        :return: The imported module object.
-
-        :raises ModuleNotFoundError: If the specified module cannot be found.
-        :raises ImportError: If there's an error during the module import process.
-        """
-        with ModuleLoader._lock, runtime:
-            return importlib.import_module(module)
-
-
 class AuxiliaryCache:
     """
     AuxiliaryCache provides access to volatile and non-volatile key-value caches associated with
@@ -263,7 +220,7 @@ class AuxiliaryCache:
         if session_id is None or session_id == "":
             raise Exception("No current session context available to retrieve volatile cache.")
 
-        return ModuleLoader.runtime().sessions().load(session_id).get_volatile_cache()
+        return Runtime.current().sessions().load(session_id).get_volatile_cache()
 
     @staticmethod
     def get_non_volatile_cache(session_id: str | None = None) -> KeyValueCache:
@@ -277,4 +234,4 @@ class AuxiliaryCache:
 
         if session_id is None or session_id == "":
             raise Exception("No current session context available to retrieve non-volatile cache.")
-        return ModuleLoader.runtime().sessions().load(session_id).get_non_volatile_cache()
+        return Runtime.current().sessions().load(session_id).get_non_volatile_cache()

--- a/ak-py/src/agentkernel/core/service.py
+++ b/ak-py/src/agentkernel/core/service.py
@@ -1,10 +1,9 @@
 import logging
 import uuid
-from typing import Any
 
-from agentkernel.core.model import AgentReply, AgentReplyText, AgentRequestText
-
-from ..core import Agent, AgentRequest, GlobalRuntime, Runtime, Session
+from ..core import Agent, AgentRequest, Runtime, Session
+from ..core.model import AgentReply, AgentReplyText, AgentRequestText
+from .runtime import ModuleLoader
 
 
 class AgentService:
@@ -17,7 +16,7 @@ class AgentService:
         self._log = logging.getLogger("ak.core.service.agentservice")
         self._agent = None
         self._session = None
-        self._runtime = GlobalRuntime.instance()
+        self._runtime = ModuleLoader.runtime()
 
     @property
     def runtime(self) -> Runtime:

--- a/ak-py/src/agentkernel/core/service.py
+++ b/ak-py/src/agentkernel/core/service.py
@@ -3,7 +3,6 @@ import uuid
 
 from ..core import Agent, AgentRequest, Runtime, Session
 from ..core.model import AgentReply, AgentReplyText, AgentRequestText
-from .runtime import ModuleLoader
 
 
 class AgentService:
@@ -16,7 +15,7 @@ class AgentService:
         self._log = logging.getLogger("ak.core.service.agentservice")
         self._agent = None
         self._session = None
-        self._runtime = ModuleLoader.runtime()
+        self._runtime = Runtime.current()
 
     @property
     def runtime(self) -> Runtime:

--- a/ak-py/src/agentkernel/core/session/base.py
+++ b/ak-py/src/agentkernel/core/session/base.py
@@ -86,7 +86,7 @@ class SessionCache:
         is at capacity, the least recently used session is removed before adding
         the new session. In either case the session is marked as most recently used.
 
-        :param session (Session): The session object to store in the cache.
+        :param session: The session object to be stored in the cache.
         """
         with self._lock:
             if session.id in self._cache:

--- a/ak-py/tests/test_runtime.py
+++ b/ak-py/tests/test_runtime.py
@@ -54,7 +54,7 @@ def test_runtime_instance_redis_when_config(monkeypatch):
     assert type(runtime.sessions()) is RedisSessionStore
 
 
-def test_runtime_instance_invalid_fallsback(monkeypatch):
+def test_runtime_instance_invalid_fallback(monkeypatch):
     class FakeCfg:
         class session:
             type = "not-a-real-type"
@@ -86,3 +86,60 @@ async def test_runtime_run_calls_runner(monkeypatch):
 
     out = await runtime.run(agent, session, [AgentRequestText(text="ping")])
     assert out.text == "ok:ping"
+
+
+@pytest.mark.asyncio
+async def test_runtime_current_default(monkeypatch):
+    """
+    Test that Runtime.current() returns GlobalRuntime by default
+    """
+
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import GlobalRuntime
+
+    current_runtime = Runtime.current()
+    assert current_runtime is not None
+    assert isinstance(current_runtime, Runtime)
+    # Should return GlobalRuntime singleton
+    assert current_runtime == GlobalRuntime.instance()
+
+
+@pytest.mark.asyncio
+async def test_runtime_current_context_manager(monkeypatch):
+    """
+    Test that Runtime.current() returns the active runtime in a context manager
+    """
+
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    agent = DummyAgent("agent")
+
+    # Before context, should get GlobalRuntime
+    from agentkernel.core.runtime import GlobalRuntime
+
+    before_runtime = Runtime.current()
+    assert before_runtime == GlobalRuntime.instance()
+
+    # Inside context, should get the specific runtime
+    with runtime:
+        current_runtime = Runtime.current()
+        assert current_runtime is runtime
+        assert current_runtime != GlobalRuntime.instance()
+
+        # Register an agent and verify it works
+        runtime.register(agent)
+        assert "agent" in runtime.agents()
+
+    # After context, should return to GlobalRuntime
+    after_runtime = Runtime.current()
+    assert after_runtime == GlobalRuntime.instance()

--- a/ak-py/tests/test_runtime.py
+++ b/ak-py/tests/test_runtime.py
@@ -143,3 +143,404 @@ async def test_runtime_current_context_manager(monkeypatch):
     # After context, should return to GlobalRuntime
     after_runtime = Runtime.current()
     assert after_runtime == GlobalRuntime.instance()
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_get_volatile_with_session_id(monkeypatch):
+    """
+    Test AuxiliaryCache.get_volatile_cache with explicit session_id
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-1")
+
+    # Get volatile cache with explicit session_id
+    v_cache = AuxiliaryCache.get_volatile_cache(session_id="test-session-1")
+    assert v_cache is not None
+
+    # Set and get a value
+    v_cache.set("test_key", "test_value")
+    assert v_cache.get("test_key") == "test_value"
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_get_non_volatile_with_session_id(monkeypatch):
+    """
+    Test AuxiliaryCache.get_non_volatile_cache with explicit session_id
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-2")
+
+    # Get non-volatile cache with explicit session_id
+    nv_cache = AuxiliaryCache.get_non_volatile_cache(session_id="test-session-2")
+    assert nv_cache is not None
+
+    # Set and get a value
+    nv_cache.set("persistent_key", "persistent_value")
+    assert nv_cache.get("persistent_key") == "persistent_value"
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_get_volatile_without_session_id_raises(monkeypatch):
+    """
+    Test that AuxiliaryCache.get_volatile_cache raises exception when no session context is available
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    # Without setting session context, should raise exception
+    with pytest.raises(Exception, match="No current session context available to retrieve volatile cache."):
+        AuxiliaryCache.get_volatile_cache()
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_get_non_volatile_without_session_id_raises(monkeypatch):
+    """
+    Test that AuxiliaryCache.get_non_volatile_cache raises exception when no session context is available
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    # Without setting session context, should raise exception
+    with pytest.raises(Exception, match="No current session context available to retrieve non-volatile cache."):
+        AuxiliaryCache.get_non_volatile_cache()
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_get_volatile_with_context_var(monkeypatch):
+    """
+    Test AuxiliaryCache.get_volatile_cache using context variable
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+    from agentkernel.core.base import current_session
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-3")
+
+    # Set the session context and use runtime context manager
+    token = current_session.set("test-session-3")
+    try:
+        with runtime:
+            # Get volatile cache without explicit session_id (should use context)
+            v_cache = AuxiliaryCache.get_volatile_cache()
+            assert v_cache is not None
+
+            # Set value via AuxiliaryCache
+            v_cache.set("context_key", "context_value")
+            
+            # Verify the value is accessible
+            assert v_cache.get("context_key") == "context_value"
+            
+            # Verify it's the same cache by checking the session's cache also has it
+            assert session.get_volatile_cache().get("context_key") == "context_value"
+    finally:
+        current_session.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_get_non_volatile_with_context_var(monkeypatch):
+    """
+    Test AuxiliaryCache.get_non_volatile_cache using context variable
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+    from agentkernel.core.base import current_session
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-4")
+
+    # Set the session context and use runtime context manager
+    token = current_session.set("test-session-4")
+    try:
+        with runtime:
+            # Get non-volatile cache without explicit session_id (should use context)
+            nv_cache = AuxiliaryCache.get_non_volatile_cache()
+            assert nv_cache is not None
+
+            # Set value via AuxiliaryCache
+            nv_cache.set("nv_context_key", "nv_context_value")
+            
+            # Verify the value is accessible
+            assert nv_cache.get("nv_context_key") == "nv_context_value"
+            
+            # Verify it's the same cache by checking the session's cache also has it
+            assert session.get_non_volatile_cache().get("nv_context_key") == "nv_context_value"
+    finally:
+        current_session.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_volatile_isolation_between_sessions(monkeypatch):
+    """
+    Test that volatile caches are isolated between different sessions
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session1 = runtime.sessions().new("test-session-5")
+    session2 = runtime.sessions().new("test-session-6")
+
+    # Get caches for both sessions
+    v_cache1 = AuxiliaryCache.get_volatile_cache(session_id="test-session-5")
+    v_cache2 = AuxiliaryCache.get_volatile_cache(session_id="test-session-6")
+
+    # Set different values in each cache
+    v_cache1.set("shared_key", "value_from_session1")
+    v_cache2.set("shared_key", "value_from_session2")
+
+    # Verify isolation
+    assert v_cache1.get("shared_key") == "value_from_session1"
+    assert v_cache2.get("shared_key") == "value_from_session2"
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_non_volatile_isolation_between_sessions(monkeypatch):
+    """
+    Test that non-volatile caches are isolated between different sessions
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session1 = runtime.sessions().new("test-session-7")
+    session2 = runtime.sessions().new("test-session-8")
+
+    # Get caches for both sessions
+    nv_cache1 = AuxiliaryCache.get_non_volatile_cache(session_id="test-session-7")
+    nv_cache2 = AuxiliaryCache.get_non_volatile_cache(session_id="test-session-8")
+
+    # Set different values in each cache
+    nv_cache1.set("shared_key", "nv_value_from_session1")
+    nv_cache2.set("shared_key", "nv_value_from_session2")
+
+    # Verify isolation
+    assert nv_cache1.get("shared_key") == "nv_value_from_session1"
+    assert nv_cache2.get("shared_key") == "nv_value_from_session2"
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_volatile_and_non_volatile_are_separate(monkeypatch):
+    """
+    Test that volatile and non-volatile caches are separate within same session
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-9")
+
+    # Get both caches for the same session
+    v_cache = AuxiliaryCache.get_volatile_cache(session_id="test-session-9")
+    nv_cache = AuxiliaryCache.get_non_volatile_cache(session_id="test-session-9")
+
+    # Set same key in both caches with different values
+    v_cache.set("common_key", "volatile_value")
+    nv_cache.set("common_key", "non_volatile_value")
+
+    # Verify they are separate
+    assert v_cache.get("common_key") == "volatile_value"
+    assert nv_cache.get("common_key") == "non_volatile_value"
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_operations_on_volatile_cache(monkeypatch):
+    """
+    Test various operations on volatile cache through AuxiliaryCache
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-10")
+
+    v_cache = AuxiliaryCache.get_volatile_cache(session_id="test-session-10")
+
+    # Test set and get
+    v_cache.set("key1", "value1")
+    assert v_cache.get("key1") == "value1"
+
+    # Test has
+    assert v_cache.has("key1") is True
+    assert v_cache.has("nonexistent") is False
+
+    # Test get with default
+    assert v_cache.get("nonexistent", "default") == "default"
+
+    # Test keys
+    v_cache.set("key2", "value2")
+    keys = v_cache.keys()
+    assert "key1" in keys
+    assert "key2" in keys
+
+    # Test delete
+    v_cache.delete("key1")
+    assert v_cache.has("key1") is False
+    assert v_cache.has("key2") is True
+
+    # Test clear
+    v_cache.clear()
+    assert len(v_cache.keys()) == 0
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_operations_on_non_volatile_cache(monkeypatch):
+    """
+    Test various operations on non-volatile cache through AuxiliaryCache
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-11")
+
+    nv_cache = AuxiliaryCache.get_non_volatile_cache(session_id="test-session-11")
+
+    # Test set and get
+    nv_cache.set("key1", "value1")
+    assert nv_cache.get("key1") == "value1"
+
+    # Test has
+    assert nv_cache.has("key1") is True
+    assert nv_cache.has("nonexistent") is False
+
+    # Test get with default
+    assert nv_cache.get("nonexistent", "default") == "default"
+
+    # Test keys
+    nv_cache.set("key2", "value2")
+    keys = nv_cache.keys()
+    assert "key1" in keys
+    assert "key2" in keys
+
+    # Test delete
+    nv_cache.delete("key1")
+    assert nv_cache.has("key1") is False
+    assert nv_cache.has("key2") is True
+
+    # Test clear
+    nv_cache.clear()
+    assert len(nv_cache.keys()) == 0
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_with_complex_data_types(monkeypatch):
+    """
+    Test AuxiliaryCache with various complex data types
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    runtime = Runtime(SessionStoreBuilder.build())
+    session = runtime.sessions().new("test-session-12")
+
+    v_cache = AuxiliaryCache.get_volatile_cache(session_id="test-session-12")
+
+    # Test with dict
+    test_dict = {"name": "test", "value": 123}
+    v_cache.set("dict_key", test_dict)
+    assert v_cache.get("dict_key") == test_dict
+
+    # Test with list
+    test_list = [1, 2, 3, "four"]
+    v_cache.set("list_key", test_list)
+    assert v_cache.get("list_key") == test_list
+
+    # Test with nested structures
+    nested_data = {
+        "level1": {
+            "level2": {
+                "items": [1, 2, 3],
+                "metadata": {"count": 3}
+            }
+        }
+    }
+    v_cache.set("nested_key", nested_data)
+    assert v_cache.get("nested_key") == nested_data
+
+
+@pytest.mark.asyncio
+async def test_auxiliary_cache_empty_session_id_raises(monkeypatch):
+    """
+    Test that empty string session_id raises exception
+    """
+    class FakeCfg:
+        class session:
+            type = "in_memory"
+
+    monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
+
+    from agentkernel.core.runtime import AuxiliaryCache
+
+    # Empty string session_id should raise exception
+    with pytest.raises(Exception, match="No current session context available to retrieve volatile cache."):
+        AuxiliaryCache.get_volatile_cache(session_id="")
+
+    with pytest.raises(Exception, match="No current session context available to retrieve non-volatile cache."):
+        AuxiliaryCache.get_non_volatile_cache(session_id="")

--- a/ak-py/tests/test_runtime.py
+++ b/ak-py/tests/test_runtime.py
@@ -150,6 +150,7 @@ async def test_auxiliary_cache_get_volatile_with_session_id(monkeypatch):
     """
     Test AuxiliaryCache.get_volatile_cache with explicit session_id
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -175,6 +176,7 @@ async def test_auxiliary_cache_get_non_volatile_with_session_id(monkeypatch):
     """
     Test AuxiliaryCache.get_non_volatile_cache with explicit session_id
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -200,6 +202,7 @@ async def test_auxiliary_cache_get_volatile_without_session_id_raises(monkeypatc
     """
     Test that AuxiliaryCache.get_volatile_cache raises exception when no session context is available
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -218,6 +221,7 @@ async def test_auxiliary_cache_get_non_volatile_without_session_id_raises(monkey
     """
     Test that AuxiliaryCache.get_non_volatile_cache raises exception when no session context is available
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -236,14 +240,15 @@ async def test_auxiliary_cache_get_volatile_with_context_var(monkeypatch):
     """
     Test AuxiliaryCache.get_volatile_cache using context variable
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
 
     monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
 
-    from agentkernel.core.runtime import AuxiliaryCache
     from agentkernel.core.base import current_session
+    from agentkernel.core.runtime import AuxiliaryCache
 
     runtime = Runtime(SessionStoreBuilder.build())
     session = runtime.sessions().new("test-session-3")
@@ -258,10 +263,10 @@ async def test_auxiliary_cache_get_volatile_with_context_var(monkeypatch):
 
             # Set value via AuxiliaryCache
             v_cache.set("context_key", "context_value")
-            
+
             # Verify the value is accessible
             assert v_cache.get("context_key") == "context_value"
-            
+
             # Verify it's the same cache by checking the session's cache also has it
             assert session.get_volatile_cache().get("context_key") == "context_value"
     finally:
@@ -273,14 +278,15 @@ async def test_auxiliary_cache_get_non_volatile_with_context_var(monkeypatch):
     """
     Test AuxiliaryCache.get_non_volatile_cache using context variable
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
 
     monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
 
-    from agentkernel.core.runtime import AuxiliaryCache
     from agentkernel.core.base import current_session
+    from agentkernel.core.runtime import AuxiliaryCache
 
     runtime = Runtime(SessionStoreBuilder.build())
     session = runtime.sessions().new("test-session-4")
@@ -295,10 +301,10 @@ async def test_auxiliary_cache_get_non_volatile_with_context_var(monkeypatch):
 
             # Set value via AuxiliaryCache
             nv_cache.set("nv_context_key", "nv_context_value")
-            
+
             # Verify the value is accessible
             assert nv_cache.get("nv_context_key") == "nv_context_value"
-            
+
             # Verify it's the same cache by checking the session's cache also has it
             assert session.get_non_volatile_cache().get("nv_context_key") == "nv_context_value"
     finally:
@@ -310,6 +316,7 @@ async def test_auxiliary_cache_volatile_isolation_between_sessions(monkeypatch):
     """
     Test that volatile caches are isolated between different sessions
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -340,6 +347,7 @@ async def test_auxiliary_cache_non_volatile_isolation_between_sessions(monkeypat
     """
     Test that non-volatile caches are isolated between different sessions
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -370,6 +378,7 @@ async def test_auxiliary_cache_volatile_and_non_volatile_are_separate(monkeypatc
     """
     Test that volatile and non-volatile caches are separate within same session
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -399,6 +408,7 @@ async def test_auxiliary_cache_operations_on_volatile_cache(monkeypatch):
     """
     Test various operations on volatile cache through AuxiliaryCache
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -444,6 +454,7 @@ async def test_auxiliary_cache_operations_on_non_volatile_cache(monkeypatch):
     """
     Test various operations on non-volatile cache through AuxiliaryCache
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -489,6 +500,7 @@ async def test_auxiliary_cache_with_complex_data_types(monkeypatch):
     """
     Test AuxiliaryCache with various complex data types
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"
@@ -513,14 +525,7 @@ async def test_auxiliary_cache_with_complex_data_types(monkeypatch):
     assert v_cache.get("list_key") == test_list
 
     # Test with nested structures
-    nested_data = {
-        "level1": {
-            "level2": {
-                "items": [1, 2, 3],
-                "metadata": {"count": 3}
-            }
-        }
-    }
+    nested_data = {"level1": {"level2": {"items": [1, 2, 3], "metadata": {"count": 3}}}}
     v_cache.set("nested_key", nested_data)
     assert v_cache.get("nested_key") == nested_data
 
@@ -530,6 +535,7 @@ async def test_auxiliary_cache_empty_session_id_raises(monkeypatch):
     """
     Test that empty string session_id raises exception
     """
+
     class FakeCfg:
         class session:
             type = "in_memory"

--- a/docs/blog/2025-12-18-hooks-and-smart-memory.md
+++ b/docs/blog/2025-12-18-hooks-and-smart-memory.md
@@ -173,7 +173,7 @@ cache = session.get_volatile_cache()
 cache.set("rag_context", retrieved_documents)
 
 # In a tool - retrieve the context
-cache = GlobalRuntime.instance().get_volatile_cache()
+cache = AuxiliaryCache.get_volatile_cache()
 docs = cache.get("rag_context")
 return query_documents(docs, question)
 ```
@@ -243,7 +243,7 @@ Check out our [key-value-cache example](https://github.com/yaalalabs/agent-kerne
 # Senior assistant with RAG hook
 @function_tool
 def query_knowledge_base(query: str) -> str:
-    cache = GlobalRuntime.instance().get_volatile_cache()
+    cache = AuxiliaryCache.get_volatile_cache()
     context = cache.get("rag_context")  # Retrieved by pre-hook
     
     if context:

--- a/docs/blog/2025-12-18-hooks-and-smart-memory.md
+++ b/docs/blog/2025-12-18-hooks-and-smart-memory.md
@@ -331,7 +331,6 @@ class SimpleRAGHook(PreHook):
 ### 3. Register and Run
 
 ```python
-from agentkernel import GlobalRuntime
 from agentkernel.openai import OpenAIModule
 from agents import Agent
 

--- a/docs/docs/architecture/memory-management.md
+++ b/docs/docs/architecture/memory-management.md
@@ -186,13 +186,13 @@ class MyHook(PreHook):
 When you don't have session access (e.g., in tools):
 
 ```python
-from agentkernel.core import GlobalRuntime
+from agentkernel import AuxiliaryCache
 from agentkernel.core.memory import KeyValueCache
 
 def my_tool():
     # Get caches from global runtime
-    v_cache: KeyValueCache = GlobalRuntime.instance().get_volatile_cache()
-    nv_cache: KeyValueCache = GlobalRuntime.instance().get_non_volatile_cache()
+    v_cache: KeyValueCache = AuxiliaryCache.get_volatile_cache()
+    nv_cache: KeyValueCache = AuxiliaryCache.get_non_volatile_cache()
     
     # Use the caches
     context = v_cache.get("rag_context")
@@ -333,9 +333,9 @@ class DataPreprocessorHook(PreHook):
 
 # In tool: Access cached data
 def my_analysis_tool():
-    from agentkernel.core import GlobalRuntime
+    from agentkernel import AuxiliaryCache
     
-    v_cache = GlobalRuntime.instance().get_volatile_cache()
+    v_cache = AuxiliaryCache.get_volatile_cache()
     data = v_cache.get("preprocessed_data")
     
     # Use preprocessed data without reprocessing

--- a/docs/docs/core-concepts/runtime.md
+++ b/docs/docs/core-concepts/runtime.md
@@ -44,11 +44,13 @@ The Runtime uses a singleton pattern - there's only one instance:
 from agentkernel.core import Runtime
 
 # Always returns the same instance
-runtime1 = Runtime.get()
-runtime2 = Runtime.get()
+runtime1 = Runtime.current()
+runtime2 = Runtime.current()
 
 assert runtime1 is runtime2  # True
 ```
+
+Alternatively you can use it as the context manager for advanced use cases (see below)
 
 ## Accessing Agents
 
@@ -57,15 +59,15 @@ assert runtime1 is runtime2  # True
 ```python
 from agentkernel.core import Runtime
 
-runtime = Runtime.get()
-agent = runtime.get_agent("assistant")
+runtime = Runtime.current()
+agent = runtime.agents().get("assistant")
 ```
 
 ### Get All Agents
 
 ```python
-runtime = Runtime.get()
-all_agents = runtime.get_all_agents()
+runtime = Runtime.current()
+all_agents = runtime.agents()
 
 for name, agent in all_agents.items():
     print(f"Agent: {name}")
@@ -74,25 +76,27 @@ for name, agent in all_agents.items():
 ### Check Agent Existence
 
 ```python
-runtime = Runtime.get()
+runtime = Runtime.current()
 
-if runtime.has_agent("assistant"):
-    agent = runtime.get_agent("assistant")
+if "assistant" in runtime.agents():
+    agent = runtime.agents()["assistant"]
 else:
     print("Agent not found")
 ```
 
 ## Session Management
 
-The Runtime manages sessions through a SessionManager:
+The Runtime manages sessions through a SessionStore:
 
 ```python
 from agentkernel.core import Runtime
 
-runtime = Runtime.get()
+runtime = Runtime.current()
 
-# Get or create session
-session = runtime.get_session("user-123")
+# Get existing session or create new one
+session = runtime.sessions().get("user-123")
+if session is None:
+    session = runtime.sessions().new("user-123")
 
 # Session is automatically persisted based on configuration
 ```
@@ -101,19 +105,15 @@ session = runtime.get_session("user-123")
 
 ## Configuration
 
-The Runtime provides access to global configuration:
+Configuration is accessed through the AKConfig singleton:
 
 ```python
-from agentkernel.core import Runtime, AKConfig
+from agentkernel.core.config import AKConfig
 
-runtime = Runtime.get()
-config = runtime.config
-
-# Or access directly
 config = AKConfig.get()
 
 print(config.log_level)
-print(config.session_storage)
+print(config.session.type)  # 'in_memory', 'redis', or 'dynamodb'
 ```
 
 ## Execution Modes
@@ -176,6 +176,53 @@ sequenceDiagram
 
 ## Advanced Usage
 
+### Custom Runtime Context
+
+For advanced use cases, you can create a custom runtime instance with specific configuration and use it as a context manager:
+
+```python
+from agentkernel.core import Runtime
+from agentkernel.core.builder import SessionStoreBuilder
+
+# Create a custom runtime instance
+custom_runtime = Runtime(SessionStoreBuilder.build())
+
+# Use it within a context
+with custom_runtime:
+    # Within this context, Runtime.current() returns custom_runtime
+    agent = MyAgent("custom-agent")
+    custom_runtime.register(agent)
+    session = custom_runtime.sessions().new("session-1")
+    
+    # Execute agent with this runtime
+    from agentkernel.core.model import AgentRequestText
+    requests = [AgentRequestText(text="Hello")]
+    result = await custom_runtime.run(agent, session, requests)
+```
+
+### Accessing the Current Runtime
+
+The `Runtime.current()` static method returns the currently active runtime instance. If called within a runtime context manager, it returns that specific runtime; otherwise, it returns the global singleton:
+
+```python
+from agentkernel.core import Runtime
+from agentkernel.core.runtime import GlobalRuntime
+
+# Outside any context, returns GlobalRuntime
+current = Runtime.current()
+assert current == GlobalRuntime.instance()
+
+# Inside a context, returns that runtime
+with custom_runtime:
+    current = Runtime.current()
+    assert current == custom_runtime
+```
+
+This pattern is particularly useful when:
+- Writing framework integrations that need access to the active runtime
+- Building utilities that work with whichever runtime is currently active
+- Testing with isolated runtime instances
+
 ### Custom Agent Registration
 
 Manually register agents (advanced):
@@ -183,10 +230,10 @@ Manually register agents (advanced):
 ```python
 from agentkernel.core import Runtime
 
-runtime = Runtime.get()
+runtime = Runtime.current()
 
 # Manually register an agent
-runtime.register_agent(custom_agent)
+runtime.register(custom_agent)
 ```
 
 ## Integration Points
@@ -216,14 +263,14 @@ runtime.register_agent(custom_agent)
 
 ### Single Runtime Instance
 
-Always use `Runtime.get()`:
+Always use `Runtime.current()` for generic usecases:
 
 ```python
 # Correct
-runtime = Runtime.get()
+runtime = Runtime.current()
 
-# Don't try to instantiate
-# runtime = Runtime()  # Won't work
+# Don't instantiate directly unless you have a specific need
+# runtime = Runtime(sessions)  # Only for advanced use cases
 ```
 
 ### Configuration Before Execution
@@ -237,7 +284,7 @@ os.environ["AK_REDIS_URL"] = "redis://localhost:6379"
 
 # Now import and use
 from agentkernel.core import Runtime
-runtime = Runtime.get()
+runtime = Runtime.current()
 ```
 
 ## Summary
@@ -247,7 +294,9 @@ runtime = Runtime.get()
 - Manages sessions
 - Provides centralized configuration
 - Supports multiple execution modes
-- Singleton pattern - use `Runtime.get()`
+- Use `Runtime.current()` to access the active runtime instance
+- Can be used as a context manager for isolated runtime contexts
+- Thread-safe runtime state management with internal locking
 
 ## Next Steps
 

--- a/examples/api/hooks/README.md
+++ b/examples/api/hooks/README.md
@@ -45,19 +45,19 @@ This order ensures that:
 
 ### Pre-Execution Hooks
 ```python
-from agentkernel import GlobalRuntime
+from agentkernel import AuxiliaryCache
 
-# Get runtime instance
-runtime = GlobalRuntime.instance()
+# Create module
+module = OpenAIModule([qa_assistant_agent])
 
 # Register pre-execution hooks in order: RAG first, then GuardRail
-runtime.register_pre_hooks("qa_assistant", [RAGHook(), GuardRailHook()])
+module.pre_hook(qa_assistant_agent, [RAGHook(), GuardRailHook()])
 ```
 
 ### Post-Execution Hooks
 ```python
 # Register post-execution hooks to add disclaimer
-runtime.register_post_hooks("qa_assistant", [DisclaimerHook()])
+module.post_hook(qa_assistant_agent, [DisclaimerHook()])
 ```
 
 ## Running the Example

--- a/examples/api/hooks/demonstration.py
+++ b/examples/api/hooks/demonstration.py
@@ -10,7 +10,7 @@ useful for understanding the core concepts and for CLI-based applications.
 import asyncio
 
 from agentkernel.core.model import AgentRequestText
-from agentkernel.core.runtime import GlobalRuntime
+from agentkernel.core.runtime import Runtime
 from agentkernel.openai import OpenAIModule
 from agents import Agent
 
@@ -30,7 +30,7 @@ async def main():
     OpenAIModule([qa_agent]).pre_hook(qa_agent, [RAGHook(), GuardRailHook()])
 
     # Get runtime and register hooks
-    runtime = GlobalRuntime.instance()
+    runtime = Runtime.current()
 
     # Get agent and create session
     agent = runtime.agents()["qa_assistant"]

--- a/examples/api/hooks/demonstration.py
+++ b/examples/api/hooks/demonstration.py
@@ -9,8 +9,8 @@ useful for understanding the core concepts and for CLI-based applications.
 
 import asyncio
 
-from agentkernel import GlobalRuntime
 from agentkernel.core.model import AgentRequestText
+from agentkernel.core.runtime import GlobalRuntime
 from agentkernel.openai import OpenAIModule
 from agents import Agent
 

--- a/examples/memory/key-value-cache/README.md
+++ b/examples/memory/key-value-cache/README.md
@@ -8,13 +8,13 @@ This example demonstrates the use of **volatile cache** and **non-volatile cache
 Session-scoped cache that stores data only for the current request execution:
 - Data is cleared after the request completes
 - Use for temporary context within a single execution
-- Accessed via: `session.get_volatile_cache() or GlobalRuntime.instance().get_volatile_cache()`
+- Accessed via: `session.get_volatile_cache() or AuxiliaryCache.get_volatile_cache()`
 
 ### Non-Volatile Cache
 Persistent cache that stores data throughout the session lifecycle:
 - Data persists across multiple requests
 - Use for extracted information from user inputs (e.g., file attachments, user preferences)
-- Accessed via: `session.get_non_volatile_cache() or GlobalRuntime.instance().get_non_volatile_cache()`
+- Accessed via: `session.get_non_volatile_cache() or AuxiliaryCache.get_non_volatile_cache()`
 
 **Usage is identical for both cache types** - the only difference is data lifetime.
 
@@ -44,7 +44,7 @@ cache.set("rag_context", relevant_contexts)
 
 **Agent Tool** (`app.py`):
 ```python
-cache = GlobalRuntime.instance().get_volatile_cache()
+cache = AuxiliaryCache.get_volatile_cache()
 rag_context = cache.get("rag_context")
 ```
 

--- a/examples/memory/key-value-cache/app.py
+++ b/examples/memory/key-value-cache/app.py
@@ -1,4 +1,4 @@
-from agentkernel import GlobalRuntime, KeyValueCache
+from agentkernel import KeyValueCache, AuxiliaryCache
 from agentkernel.api import RESTAPI
 from agentkernel.openai import OpenAIModule
 from agents import Agent, function_tool
@@ -14,7 +14,7 @@ def query_private_knowledge_base(query: str) -> str:
     """
     # knowledge base
     kb = []
-    cache: KeyValueCache = GlobalRuntime.instance().get_volatile_cache()
+    cache: KeyValueCache = AuxiliaryCache.get_volatile_cache()
     rag_context = cache.get("rag_context")
     print(f"***************** query_private_knowledge_base: Retrieved context from volatile cache: {rag_context}")
     if rag_context:


### PR DESCRIPTION
## Description
There was no way of accessing the auxiliary cache without accessing the `Runtime` object for users. This PR solves that by introducing `AuxiliaryCache` class. 

Direct exposure of `GlobalRuntime` class has also been removed.

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update
- [ ] CI/CD update
- [ ] Other (please describe):

## Related Issues
<!-- Link to related issues using #issue_number -->


## Changes Made
<!-- List the main changes made in this PR -->

- Introduced `AuxiliaryCache`
- Replaced `GlobalRuntime` access with `ModuleLoader` wherever needed
- Documentation and examples have been updated

## Testing
<!-- Describe the testing you have performed -->

- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [x] Manual testing completed
- [ ] New tests added for changes

## Checklist
<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the PR here -->