### PR TITLE
aws serverless docs command update

### DIFF
--- a/docs/docs/deployment/aws-serverless.md
+++ b/docs/docs/deployment/aws-serverless.md
@@ -41,7 +41,7 @@ Refer to [Terraform modules](https://registry.terraform.io/modules/yaalalabs/ak-
 ### 3. Deploy
 
 ```bash
-terraform init && terraform deploy
+terraform init && terraform apply
 ```
 
 ## Lambda Handler


### PR DESCRIPTION
## Description
Changed the `terraform deploy` command to `terraform apply` in the AWS Serverless Deployment documentation

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] CI/CD update
- [ ] Other (please describe):