### PR TITLE
feat: making sure agent call invocation on runtime is asyncio friendly and runs in a serial manner

### DIFF
--- a/ak-py/src/agentkernel/core/base.py
+++ b/ak-py/src/agentkernel/core/base.py
@@ -104,8 +104,12 @@ class Session:
         :raises: Any exceptions that may occur during lock acquisition or session setting.
         """
         await self._lock.acquire()
-        self._token = Session.current_session.set(self)
-        return self
+        try:
+            self._token = Session.current_session.set(self)
+            return self
+        except Exception:
+            self._lock.release()
+            raise
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         """

--- a/ak-py/src/agentkernel/core/base.py
+++ b/ak-py/src/agentkernel/core/base.py
@@ -109,10 +109,13 @@ class Session:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        if self._token:
-            Session.current_session.reset(self._token)
+        try:
+            if self._token:
+                Session.current_session.reset(self._token)
+        finally:
             self._token = None
-        self._lock.release()
+            if self._lock.locked():
+                self._lock.release()
 
     @property
     def id(self) -> str:
@@ -211,6 +214,7 @@ class Session:
         """
         if self._token:
             Session.current_session.reset(self._token)
+            self._token = None
 
 
 class Runner(ABC):

--- a/ak-py/src/agentkernel/core/base.py
+++ b/ak-py/src/agentkernel/core/base.py
@@ -42,11 +42,11 @@ class Session:
         VOLATILE_CACHE = "v_cache"
         NON_VOLATILE_CACHE = "nv_cache"
 
-    # deprecated(version="0.2.12", reason="Use Session.Keys.VOLATILE_CACHE.value instead.")
-    VOLATILE_CACHE_KEY = Keys.VOLATILE_CACHE.value
+    VOLATILE_CACHE_KEY: str = Keys.VOLATILE_CACHE.value
+    """Deprecated since 0.2.12, use Session.Keys.VOLATILE_CACHE.value instead."""
 
-    # deprecated(version="0.2.12", reason="Use Session.Keys.NON_VOLATILE_CACHE.value instead.")
-    NON_VOLATILE_CACHE_KEY = Keys.NON_VOLATILE_CACHE.value
+    NON_VOLATILE_CACHE_KEY: str = Keys.NON_VOLATILE_CACHE.value
+    """Deprecated since 0.2.12, use Session.Keys.NON_VOLATILE_CACHE.value instead."""
 
     current_session: contextvars.ContextVar["Session"] = contextvars.ContextVar("current_session", default=None)
 
@@ -100,7 +100,6 @@ class Session:
         It acquires the internal lock to ensure that the session is used by only one coroutine
         at a time. It also sets the current session context variable.
 
-        :param self: The Session instance entering the context.
         :return: The same instance (self) to be used within the async with block.
         :raises: Any exceptions that may occur during lock acquisition or session setting.
         """
@@ -109,13 +108,24 @@ class Session:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """
+        Async context manager exit method that releases the lock and resets the current session.
+        This method is called when exiting an async context manager (using 'async with').
+        It releases the internal lock to allow other coroutines to use the session.
+        It also resets the current session context variable to its previous value.
+
+        :param exc_type: The type of exception raised (if any).
+        :param exc_val: The value of the exception raised (if any).
+        :param exc_tb: The traceback of the exception raised (if any).
+        :return: None
+        :raises: Any exceptions that may occur during lock release or session resetting.
+        """
         try:
             if self._token:
                 Session.current_session.reset(self._token)
         finally:
             self._token = None
-            if self._lock.locked():
-                self._lock.release()
+            self._lock.release()
 
     @property
     def id(self) -> str:
@@ -203,7 +213,7 @@ class Session:
     @deprecated(version="0.2.12", reason="Use async with on the session to acquire it.")
     def set_context(self):
         """
-        Sets the current session context variable to this session's ID.
+        Sets the current session context variable to this session.
         """
         self._token = Session.current_session.set(self)
 

--- a/ak-py/src/agentkernel/core/base.py
+++ b/ak-py/src/agentkernel/core/base.py
@@ -1,14 +1,16 @@
+import asyncio
 import contextvars
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, List
+from enum import Enum
+from typing import Any, List, Self
 
-from ..core.hooks import PostHook, PreHook
+from deprecated import deprecated
+
 from .config import AKConfig
+from .hooks import PostHook, PreHook
 from .model import AgentReply, AgentRequest
 from .util.key_value_cache import KeyValueCache
-
-current_session = contextvars.ContextVar("session_id", default="")
 
 
 class Session:
@@ -19,8 +21,8 @@ class Session:
     allowing the runtime to track and share state across multiple related agent logic invocations.
 
     Sessions may be volatile (meaning that they are not persisted) or durable (meaning that they
-    are persisted and are available across multiple invocations of the runtime). This is governed by
-    the runtime configuration.
+    are persisted and are available across multiple instantiations of the runtime). This is governed
+    by the runtime configuration.
 
     Session class stores framework-specific session data objects in a key-value store, allowing
     different agent frameworks to store and retrieve their own session data without interfering with
@@ -32,46 +34,85 @@ class Session:
     agent context but needs to be retained across multiple interactions within the same session.
     """
 
-    VOLATILE_CACHE_KEY = "v_cache"
-    NON_VOLATILE_CACHE_KEY = "nv_cache"
+    class Keys(Enum):
+        """
+        Pre-defined session data keys for caches.
+        """
+
+        VOLATILE_CACHE = "v_cache"
+        NON_VOLATILE_CACHE = "nv_cache"
+
+    # deprecated(version="0.2.12", reason="Use Session.Keys.VOLATILE_CACHE.value instead.")
+    VOLATILE_CACHE_KEY = Keys.VOLATILE_CACHE.value
+
+    # deprecated(version="0.2.12", reason="Use Session.Keys.NON_VOLATILE_CACHE.value instead.")
+    NON_VOLATILE_CACHE_KEY = Keys.NON_VOLATILE_CACHE.value
+
+    current_session: contextvars.ContextVar["Session"] = contextvars.ContextVar("current_session", default=None)
 
     @classmethod
+    def current(cls) -> Self | None:
+        """
+        Returns the current session.
+        :return: The current Session instance.
+        """
+        return cls.current_session.get()
+
+    @classmethod
+    @deprecated(version="0.2.12", reason="Use Session.current() instead.")
     def get_current_session_id(cls) -> str:
         """
         Returns the current session identifier from the context variable.
         :return: The current session identifier.
         """
-        return current_session.get()
-
-    def get_volatile_cache(self) -> KeyValueCache:
-        """
-        Returns the volatile key-value cache associated with this session.
-        :return: The volatile KeyValueCache instance.
-        """
-        return self.get(self.VOLATILE_CACHE_KEY)
-
-    def get_non_volatile_cache(self) -> KeyValueCache:
-        """
-        Returns the non-volatile key-value cache associated with this session.
-        :return: The non-volatile KeyValueCache instance.
-        """
-        return self.get(self.NON_VOLATILE_CACHE_KEY)
+        session = cls.current()
+        return session.id if session else ""
 
     def __init__(self, id: str):
         """
         Initializes a Session instance.
         :param id: Unique identifier for the session.
         """
-        self._log = logging.getLogger("ak.core.session")
+        self._log = logging.getLogger(f"ak.core.session [{id}]")
         self._id = id
         self._data = {}
+        self._lock = asyncio.Lock()
 
         # Pre-initialize key-value caches to be used by application code
         # which will not be part of the agent context.
-        self.set(self.VOLATILE_CACHE_KEY, KeyValueCache())
-        self.set(self.NON_VOLATILE_CACHE_KEY, KeyValueCache())
+        self.set(Session.Keys.VOLATILE_CACHE.value, KeyValueCache())
+        self.set(Session.Keys.NON_VOLATILE_CACHE.value, KeyValueCache())
 
         self._token = None
+
+    def __repr__(self):
+        """
+        Returns a string representation of the Session instance.
+        :return: String representation of the Session.
+        """
+        return f"Session(id={self._id})"
+
+    async def __aenter__(self) -> Self:
+        """
+        Async context manager entry method that acquires a lock and sets the current session.
+        This method is called when entering an async context manager (using 'async with').
+
+        It acquires the internal lock to ensure that the session is used by only one coroutine
+        at a time. It also sets the current session context variable.
+
+        :param self: The Session instance entering the context.
+        :return: The same instance (self) to be used within the async with block.
+        :raises: Any exceptions that may occur during lock acquisition or session setting.
+        """
+        await self._lock.acquire()
+        self._token = Session.current_session.set(self)
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._token:
+            Session.current_session.reset(self._token)
+            self._token = None
+        self._lock.release()
 
     @property
     def id(self) -> str:
@@ -89,9 +130,10 @@ class Session:
         if there is no data object with the specified key.
         """
         result = self._data.get(key)
-        self._log.debug(f"Retrieved session {self._id} data object for key {key}: {result}")
+        self._log.debug(f"Retrieved session data object for key {key}: {result}")
         return result
 
+    @deprecated(version="0.2.12", reason="Use get_all() instead.")
     def get_all_keys(self):
         """
         Returns a list of all keys in the session data.
@@ -99,13 +141,38 @@ class Session:
         """
         return self._data.keys()
 
+    def get_all(self, durable: bool = True, volatile: bool = True):
+        """
+        Returns all session data objects.
+        :param durable: Whether to include non-volatile (durable) data objects.
+        :param volatile: Whether to include volatile data objects.
+        :return: Iterator over matching session object key value pairs.
+        """
+        for key, value in self._data.items():
+            if (durable and key != Session.Keys.VOLATILE_CACHE.value) or (volatile and key == Session.Keys.VOLATILE_CACHE.value):
+                yield key, value
+
+    def get_volatile_cache(self) -> KeyValueCache:
+        """
+        Returns the volatile key-value cache associated with this session.
+        :return: The volatile KeyValueCache instance.
+        """
+        return self.get(Session.Keys.VOLATILE_CACHE.value)
+
+    def get_non_volatile_cache(self) -> KeyValueCache:
+        """
+        Returns the non-volatile key-value cache associated with this session.
+        :return: The non-volatile KeyValueCache instance.
+        """
+        return self.get(Session.Keys.NON_VOLATILE_CACHE.value)
+
     def set(self, key: str, value: Any) -> Any:
         """
         Sets a session data object for the specified key.
         :param key: The key of the session data object.
         :param value: The session data object.
         """
-        self._log.debug(f"Setting session {self._id} data object for key {key}: {value}")
+        self._log.debug(f"Setting session data object for key {key}: {value}")
         self._data[key] = value
         return value
 
@@ -115,33 +182,35 @@ class Session:
         :param key: The key of the session data object to be deleted.
         """
         if key in self._data:
-            self._log.debug(f"Deleting session {self._id} data object for key {key}")
+            self._log.debug(f"Deleting session data object for key {key}")
             del self._data[key]
 
     def clear(self) -> None:
         """
         Clears all session data objects.
         """
-        self._log.debug(f"Clearing session {self._id} data objects")
+        self._log.debug(f"Clearing all session data objects")
         self._data = {
-            self.VOLATILE_CACHE_KEY: self.get_volatile_cache(),
-            self.NON_VOLATILE_CACHE_KEY: self.get_non_volatile_cache(),
+            Session.Keys.VOLATILE_CACHE.value: self.get_volatile_cache(),
+            Session.Keys.NON_VOLATILE_CACHE.value: self.get_non_volatile_cache(),
         }
         self.get_volatile_cache().clear()
         self.get_non_volatile_cache().clear()
 
+    @deprecated(version="0.2.12", reason="Use async with on the session to acquire it.")
     def set_context(self):
         """
         Sets the current session context variable to this session's ID.
         """
-        self._token = current_session.set(self._id)
+        self._token = Session.current_session.set(self)
 
+    @deprecated(version="0.2.12", reason="Use async with on the session to acquire it.")
     def reset_context(self):
         """
         Resets the current session context variable to the previous value.
         """
         if self._token:
-            current_session.reset(self._token)
+            Session.current_session.reset(self._token)
 
 
 class Runner(ABC):

--- a/ak-py/src/agentkernel/core/runtime.py
+++ b/ak-py/src/agentkernel/core/runtime.py
@@ -135,37 +135,38 @@ class Runtime:
                         AgentRequestAny is handled only by pre-hooks, not by the agent itself
         :return: The result of the agent's execution.
         """
-        self._log.debug(f"Executing pre hooks with agent '{agent.name}' and requests: {requests}")
+        async with session:
+            self._log.debug(f"Executing pre hooks with agent '{agent.name}' and requests: {requests}")
 
-        pre_hooks = agent.pre_hooks + self._system_pre_hooks  # system pre-hooks are always executed last
-        for hook in pre_hooks:
-            reply = await hook.on_run(session, agent, requests)
-            if isinstance(reply, (AgentReplyText, AgentReplyImage)):
-                self._log.debug(f"PreHook halted execution for agent '{agent.name}' by hook '{hook.name()}' with reply: {reply}")
-                return reply
+            pre_hooks = agent.pre_hooks + self._system_pre_hooks  # system pre-hooks are always executed last
+            for hook in pre_hooks:
+                reply = await hook.on_run(session, agent, requests)
+                if isinstance(reply, (AgentReplyText, AgentReplyImage)):
+                    self._log.debug(f"PreHook halted execution for agent '{agent.name}' by hook '{hook.name()}' with reply: {reply}")
+                    return reply
 
-            # Validation to ensure the correct type is returned from the hooks. This is important to avoid runtime errors.
-            if isinstance(reply, list):
-                for item in reply:
-                    if not isinstance(item, (AgentRequestText, AgentRequestFile, AgentRequestImage, AgentRequestAny)):
-                        raise TypeError(
-                            f"PreHook '{hook.name()}' returned an invalid type in the requests list. Expected AgentRequest, got {type(item)}"
-                        )
-            else:
-                raise TypeError(f"PreHook '{hook.name()}' returned an invalid type. Expected list[AgentRequest], got {type(reply)}")
-            requests = reply
+                # Validation to ensure the correct type is returned from the hooks. This is important to avoid runtime errors.
+                if isinstance(reply, list):
+                    for item in reply:
+                        if not isinstance(item, (AgentRequestText, AgentRequestFile, AgentRequestImage, AgentRequestAny)):
+                            raise TypeError(
+                                f"PreHook '{hook.name()}' returned an invalid type in the requests list. Expected AgentRequest, got {type(item)}"
+                            )
+                else:
+                    raise TypeError(f"PreHook '{hook.name()}' returned an invalid type. Expected list[AgentRequest], got {type(reply)}")
+                requests = reply
 
-        self._log.debug(f"Running agent '{agent.name}' with requests: {requests}")
+            self._log.debug(f"Running agent '{agent.name}' with requests: {requests}")
 
-        reply = await agent.runner.run(agent, session, requests)
+            reply = await agent.runner.run(agent, session, requests)
 
-        post_hooks = self._system_post_hooks + agent.post_hooks  # system post-hooks are always executed first
-        for hook in post_hooks:
-            reply = await hook.on_run(session, requests, agent, reply)
-            if not isinstance(reply, (AgentReplyText, AgentReplyImage)):
-                raise TypeError(f"PostHook '{hook.name()}' returned an invalid type. Expected AgentReply, got {type(reply)}")
-            self._log.debug(f"PostHook executed for agent '{agent.name}' by hook '{hook.name()}' reply: {reply}")
-        return reply
+            post_hooks = self._system_post_hooks + agent.post_hooks  # system post-hooks are always executed first
+            for hook in post_hooks:
+                reply = await hook.on_run(session, requests, agent, reply)
+                if not isinstance(reply, (AgentReplyText, AgentReplyImage)):
+                    raise TypeError(f"PostHook '{hook.name()}' returned an invalid type. Expected AgentReply, got {type(reply)}")
+                self._log.debug(f"PostHook executed for agent '{agent.name}' by hook '{hook.name()}' reply: {reply}")
+            return reply
 
     def sessions(self) -> SessionStore:
         """
@@ -208,27 +209,23 @@ class AuxiliaryCache:
     def get_volatile_cache(session_id: str | None = None) -> KeyValueCache:
         """
         Retrieves the volatile key-value cache associated with the provided session.
-        :param session_id: The session to retrieve the volatile cache for. If not provided, the current context is used to find the session
+        :param session_id: The session to retrieve the volatile cache for. If not provided, the current session is used to find the session
         :return: The volatile key-value cache.
         """
-        if session_id is None:
-            session_id = Session.get_current_session_id()
+        session = Runtime.current().sessions().load(session_id) if session_id else Session.current()
+        if session is None:
+            raise Exception("No current or matching session available to retrieve volatile cache.")
 
-        if session_id is None or session_id == "":
-            raise Exception("No current session context available to retrieve volatile cache.")
-
-        return Runtime.current().sessions().load(session_id).get_volatile_cache()
+        return session.get_volatile_cache()
 
     @staticmethod
     def get_non_volatile_cache(session_id: str | None = None) -> KeyValueCache:
         """
         Retrieves the non-volatile key-value cache associated with the provided session.
-        :param session_id: The session to retrieve the non-volatile cache for. If not provided, the current context is used to find the session
+        :param session_id: The session to retrieve the non-volatile cache for. If not provided, the current session is used to find the session
         :return: The non-volatile key-value cache.
         """
-        if session_id is None:
-            session_id = Session.get_current_session_id()
-
-        if session_id is None or session_id == "":
-            raise Exception("No current session context available to retrieve non-volatile cache.")
-        return Runtime.current().sessions().load(session_id).get_non_volatile_cache()
+        session = Runtime.current().sessions().load(session_id) if session_id else Session.current()
+        if session is None:
+            raise Exception("No current or matching session available to retrieve non-volatile cache.")
+        return session.get_non_volatile_cache()

--- a/ak-py/src/agentkernel/core/runtime.py
+++ b/ak-py/src/agentkernel/core/runtime.py
@@ -128,6 +128,9 @@ class Runtime:
         """
         Runs the specified agent with the multi-modal requests.
 
+        Note that the volatile cache is cleared after execution, including when the execution is halted by a hook.
+        On successful completion, the session stored is updated.
+
         :param agent: The agent to run.
         :param session: The session to use for the agent.
         :param requests: The multi-modal inputs are provided to the agent.  It will be submitted to the agent as a single request
@@ -136,37 +139,42 @@ class Runtime:
         :return: The result of the agent's execution.
         """
         async with session:
-            self._log.debug(f"Executing pre hooks with agent '{agent.name}' and requests: {requests}")
+            try:
+                self._log.debug(f"Executing pre hooks with agent '{agent.name}' and requests: {requests}")
 
-            pre_hooks = agent.pre_hooks + self._system_pre_hooks  # system pre-hooks are always executed last
-            for hook in pre_hooks:
-                reply = await hook.on_run(session, agent, requests)
-                if isinstance(reply, (AgentReplyText, AgentReplyImage)):
-                    self._log.debug(f"PreHook halted execution for agent '{agent.name}' by hook '{hook.name()}' with reply: {reply}")
-                    return reply
+                pre_hooks = agent.pre_hooks + self._system_pre_hooks  # system pre-hooks are always executed last
+                for hook in pre_hooks:
+                    reply = await hook.on_run(session, agent, requests)
+                    if isinstance(reply, (AgentReplyText, AgentReplyImage)):
+                        self._log.debug(f"PreHook halted execution for agent '{agent.name}' by hook '{hook.name()}' with reply: {reply}")
+                        return reply
 
-                # Validation to ensure the correct type is returned from the hooks. This is important to avoid runtime errors.
-                if isinstance(reply, list):
-                    for item in reply:
-                        if not isinstance(item, (AgentRequestText, AgentRequestFile, AgentRequestImage, AgentRequestAny)):
-                            raise TypeError(
-                                f"PreHook '{hook.name()}' returned an invalid type in the requests list. Expected AgentRequest, got {type(item)}"
-                            )
-                else:
-                    raise TypeError(f"PreHook '{hook.name()}' returned an invalid type. Expected list[AgentRequest], got {type(reply)}")
-                requests = reply
+                    # Validation to ensure the correct type is returned from the hooks. This is important to avoid runtime errors.
+                    if isinstance(reply, list):
+                        for item in reply:
+                            if not isinstance(item, (AgentRequestText, AgentRequestFile, AgentRequestImage, AgentRequestAny)):
+                                raise TypeError(
+                                    f"PreHook '{hook.name()}' returned an invalid type in the requests list. Expected AgentRequest, got {type(item)}"
+                                )
+                    else:
+                        raise TypeError(f"PreHook '{hook.name()}' returned an invalid type. Expected list[AgentRequest], got {type(reply)}")
+                    requests = reply
 
-            self._log.debug(f"Running agent '{agent.name}' with requests: {requests}")
+                self._log.debug(f"Running agent '{agent.name}' with requests: {requests}")
 
-            reply = await agent.runner.run(agent, session, requests)
+                reply = await agent.runner.run(agent, session, requests)
 
-            post_hooks = self._system_post_hooks + agent.post_hooks  # system post-hooks are always executed first
-            for hook in post_hooks:
-                reply = await hook.on_run(session, requests, agent, reply)
-                if not isinstance(reply, (AgentReplyText, AgentReplyImage)):
-                    raise TypeError(f"PostHook '{hook.name()}' returned an invalid type. Expected AgentReply, got {type(reply)}")
-                self._log.debug(f"PostHook executed for agent '{agent.name}' by hook '{hook.name()}' reply: {reply}")
-            return reply
+                post_hooks = self._system_post_hooks + agent.post_hooks  # system post-hooks are always executed first
+                for hook in post_hooks:
+                    reply = await hook.on_run(session, requests, agent, reply)
+                    if not isinstance(reply, (AgentReplyText, AgentReplyImage)):
+                        raise TypeError(f"PostHook '{hook.name()}' returned an invalid type. Expected AgentReply, got {type(reply)}")
+                    self._log.debug(f"PostHook executed for agent '{agent.name}' by hook '{hook.name()}' reply: {reply}")
+
+                self.sessions().store(session)
+                return reply
+            finally:
+                session.get_volatile_cache().clear()
 
     def sessions(self) -> SessionStore:
         """

--- a/ak-py/src/agentkernel/core/service.py
+++ b/ak-py/src/agentkernel/core/service.py
@@ -145,12 +145,12 @@ class AgentService:
             raise ValueError("No agent selected. Please select an agent before running.")
         if not self._session:
             raise ValueError("No session available. Please create or load a session before running.")
-        self._session.set_context()
-        result = await self._runtime.run(self._agent, self._session, requests)
-        self._runtime.sessions().store(self._session)
-        self._session.get_volatile_cache().clear()
-        self._session.reset_context()
-        return result
+
+        with self._session:
+            result = await self._runtime.run(self._agent, self._session, requests)
+            self._runtime.sessions().store(self._session)
+            self._session.get_volatile_cache().clear()
+            return result
 
     def get_response_session_id(self, session_id: str | None = None) -> str | None:
         """

--- a/ak-py/src/agentkernel/core/service.py
+++ b/ak-py/src/agentkernel/core/service.py
@@ -146,11 +146,8 @@ class AgentService:
         if not self._session:
             raise ValueError("No session available. Please create or load a session before running.")
 
-        with self._session:
-            result = await self._runtime.run(self._agent, self._session, requests)
-            self._runtime.sessions().store(self._session)
-            self._session.get_volatile_cache().clear()
-            return result
+        result = await self._runtime.run(self._agent, self._session, requests)
+        return result
 
     def get_response_session_id(self, session_id: str | None = None) -> str | None:
         """

--- a/ak-py/src/agentkernel/core/session/dynamodb.py
+++ b/ak-py/src/agentkernel/core/session/dynamodb.py
@@ -244,10 +244,7 @@ class DynamoDBSessionStore(SessionStore):
         Persist all session key/value pairs as individual DynamoDB items.
         :param session: The session to persist.
         """
-        for key in session.get_all_keys():
-            if key == Session.VOLATILE_CACHE_KEY:  # Do not store volatile cache
-                continue
-            value = session.get(key)
+        for key, value in session.get_all(volatile=False):
             payload = self._serde.dumps(value)
             self._driver.put(session.id, key, payload)
         if self._cache:

--- a/ak-py/src/agentkernel/core/session/redis.py
+++ b/ak-py/src/agentkernel/core/session/redis.py
@@ -211,10 +211,7 @@ class RedisSessionStore(SessionStore):
         Stores a session or updates it if it already exists in the storage.
         :param session: The session to store.
         """
-        for key in session.get_all_keys():
-            if key == Session.VOLATILE_CACHE_KEY:  # Do not store volatile cache
-                continue
-            value = session.get(key)
+        for key, value in session.get_all(volatile=False):
             self._driver.hset(self._driver.key(session.id), key, self._serde.dumps(value))
         if self._driver.ttl:
             self._driver.expire(self._driver.key(session.id))

--- a/ak-py/src/agentkernel/framework/openai/openai.py
+++ b/ak-py/src/agentkernel/framework/openai/openai.py
@@ -26,7 +26,7 @@ from ...trace import Trace
 FRAMEWORK = "openai"
 
 
-class OpenAISession(SessionABC):
+class OpenAISession:
     """
     OpenAISession class provides a session for OpenAI Agents SDK-based agents.
     """

--- a/ak-py/tests/test_runtime.py
+++ b/ak-py/tests/test_runtime.py
@@ -1,6 +1,6 @@
 import pytest
 
-from agentkernel import Agent, Runner
+from agentkernel import Agent, Runner, Session
 from agentkernel.core.builder import SessionStoreBuilder
 from agentkernel.core.model import AgentReplyText, AgentRequestText
 from agentkernel.core.runtime import Runtime
@@ -212,7 +212,7 @@ async def test_auxiliary_cache_get_volatile_without_session_id_raises(monkeypatc
     from agentkernel.core.runtime import AuxiliaryCache
 
     # Without setting session context, should raise exception
-    with pytest.raises(Exception, match="No current session context available to retrieve volatile cache."):
+    with pytest.raises(Exception, match="No current or matching session available to retrieve volatile cache."):
         AuxiliaryCache.get_volatile_cache()
 
 
@@ -231,7 +231,7 @@ async def test_auxiliary_cache_get_non_volatile_without_session_id_raises(monkey
     from agentkernel.core.runtime import AuxiliaryCache
 
     # Without setting session context, should raise exception
-    with pytest.raises(Exception, match="No current session context available to retrieve non-volatile cache."):
+    with pytest.raises(Exception, match="No current or matching session available to retrieve non-volatile cache."):
         AuxiliaryCache.get_non_volatile_cache()
 
 
@@ -247,16 +247,12 @@ async def test_auxiliary_cache_get_volatile_with_context_var(monkeypatch):
 
     monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
 
-    from agentkernel.core.base import current_session
     from agentkernel.core.runtime import AuxiliaryCache
 
     runtime = Runtime(SessionStoreBuilder.build())
-    session = runtime.sessions().new("test-session-3")
-
-    # Set the session context and use runtime context manager
-    token = current_session.set("test-session-3")
-    try:
-        with runtime:
+    with runtime:
+        session = runtime.sessions().new("test-session-3")
+        async with session:
             # Get volatile cache without explicit session_id (should use context)
             v_cache = AuxiliaryCache.get_volatile_cache()
             assert v_cache is not None
@@ -269,8 +265,6 @@ async def test_auxiliary_cache_get_volatile_with_context_var(monkeypatch):
 
             # Verify it's the same cache by checking the session's cache also has it
             assert session.get_volatile_cache().get("context_key") == "context_value"
-    finally:
-        current_session.reset(token)
 
 
 @pytest.mark.asyncio
@@ -285,16 +279,12 @@ async def test_auxiliary_cache_get_non_volatile_with_context_var(monkeypatch):
 
     monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: FakeCfg))
 
-    from agentkernel.core.base import current_session
     from agentkernel.core.runtime import AuxiliaryCache
 
     runtime = Runtime(SessionStoreBuilder.build())
-    session = runtime.sessions().new("test-session-4")
-
-    # Set the session context and use runtime context manager
-    token = current_session.set("test-session-4")
-    try:
-        with runtime:
+    with runtime:
+        session = runtime.sessions().new("test-session-4")
+        async with session:
             # Get non-volatile cache without explicit session_id (should use context)
             nv_cache = AuxiliaryCache.get_non_volatile_cache()
             assert nv_cache is not None
@@ -307,8 +297,6 @@ async def test_auxiliary_cache_get_non_volatile_with_context_var(monkeypatch):
 
             # Verify it's the same cache by checking the session's cache also has it
             assert session.get_non_volatile_cache().get("nv_context_key") == "nv_context_value"
-    finally:
-        current_session.reset(token)
 
 
 @pytest.mark.asyncio
@@ -545,8 +533,8 @@ async def test_auxiliary_cache_empty_session_id_raises(monkeypatch):
     from agentkernel.core.runtime import AuxiliaryCache
 
     # Empty string session_id should raise exception
-    with pytest.raises(Exception, match="No current session context available to retrieve volatile cache."):
+    with pytest.raises(Exception, match="No current or matching session available to retrieve volatile cache."):
         AuxiliaryCache.get_volatile_cache(session_id="")
 
-    with pytest.raises(Exception, match="No current session context available to retrieve non-volatile cache."):
+    with pytest.raises(Exception, match="No current or matching session available to retrieve non-volatile cache."):
         AuxiliaryCache.get_non_volatile_cache(session_id="")

--- a/ak-py/tests/test_runtime.py
+++ b/ak-py/tests/test_runtime.py
@@ -1,6 +1,6 @@
 import pytest
 
-from agentkernel import Agent, Runner, Session
+from agentkernel import Agent, Runner
 from agentkernel.core.builder import SessionStoreBuilder
 from agentkernel.core.model import AgentReplyText, AgentRequestText
 from agentkernel.core.runtime import Runtime

--- a/ak-py/tests/test_session.py
+++ b/ak-py/tests/test_session.py
@@ -79,11 +79,11 @@ def test_session_clear():
 
 def test_current_session_deprecated_api():
     session = Session("test-session")
-    assert Session.get_current_session_id() is ""
+    assert Session.get_current_session_id() == ""
     session.set_context()
     assert Session.get_current_session_id() == "test-session"
     session.reset_context()
-    assert Session.get_current_session_id() is ""
+    assert Session.get_current_session_id() == ""
 
 
 @pytest.mark.asyncio

--- a/ak-py/tests/test_session.py
+++ b/ak-py/tests/test_session.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from agentkernel.core.base import Session
@@ -93,3 +94,22 @@ async def test_current_session():
     async with session:
         assert Session.current() == session
     assert Session.current() is None
+
+
+@pytest.mark.asyncio
+async def test_session_serial_access():
+    session = Session("test-session")
+    session.set("key", 0)
+
+    async def update_session(pre, val, timeout):
+        async with session:
+            assert pre == session.get("key")
+            session.set("key", val)
+            await asyncio.sleep(timeout)
+            assert val == session.get("key")
+
+    await asyncio.gather(
+        update_session(0, 1, 0.1),
+        update_session(1, 2, 0.05),
+        update_session(2, 3, 0.01),
+    )

--- a/ak-py/tests/test_session.py
+++ b/ak-py/tests/test_session.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import pytest
 
 from agentkernel.core.base import Session

--- a/ak-py/tests/test_session.py
+++ b/ak-py/tests/test_session.py
@@ -1,10 +1,19 @@
+import pytest
+
 from agentkernel.core.base import Session
 
 
 def test_session_init():
     session = Session("test-session")
     assert session.id == "test-session"
-    assert len(session.get_all_keys()) == 2
+    assert repr(session) == "Session(id=test-session)"
+
+    assert len(session.get_all_keys()) == 2  # deprecated
+    assert sum(1 for _, _ in session.get_all()) == 2
+    assert sum(1 for _, _ in session.get_all(durable=False)) == 1
+    assert sum(1 for _, _ in session.get_all(volatile=False)) == 1
+    assert sum(1 for _, _ in session.get_all(durable=False, volatile=False)) == 0
+
     assert session.get_volatile_cache() is not None
     assert len(session.get_volatile_cache().keys()) == 0
     assert session.get_non_volatile_cache() is not None
@@ -14,8 +23,10 @@ def test_session_init():
 def test_session_set_get():
     session = Session("test-session")
     session.set("key1", "value1")
+    assert sum(1 for _, _ in session.get_all()) == 3
     assert session.get("key1") == "value1"
-    assert "key1" in session.get_all_keys()
+    assert "key1" in session.get_all_keys()  # deprecated
+    assert "key1" in list(k for k, _ in session.get_all())
     assert session.get("nonexistent") is None
 
 
@@ -25,9 +36,11 @@ def test_session_delete():
     session.set("key2", "value2")
     session.delete("key1")
     assert session.get("key1") is None
-    assert "key1" not in session.get_all_keys()
+    assert "key1" not in session.get_all_keys()  # deprecated
+    assert "key1" not in list(k for k, _ in session.get_all())
     assert session.get("key2") == "value2"
-    assert "key2" in session.get_all_keys()
+    assert "key2" in session.get_all_keys()  # deprecated
+    assert "key2" in list(k for k, _ in session.get_all())
 
 
 def test_session_volatile_cache():
@@ -54,10 +67,29 @@ def test_session_clear():
     session.get_non_volatile_cache().set("nvkey1", "nvvalue1")
     session.clear()
     assert session.id == "test-session"
-    assert len(session.get_all_keys()) == 2
+    assert len(session.get_all_keys()) == 2  # deprecated
+    assert sum(1 for _, _ in session.get_all()) == 2
     assert session.get("key1") is None
     assert session.get("key2") is None
     assert len(session.get_volatile_cache().keys()) == 0
     assert session.get_volatile_cache().get("vkey1") is None
     assert len(session.get_non_volatile_cache().keys()) == 0
     assert session.get_non_volatile_cache().get("nvkey1") is None
+
+
+def test_current_session_deprecated_api():
+    session = Session("test-session")
+    assert Session.get_current_session_id() is ""
+    session.set_context()
+    assert Session.get_current_session_id() == "test-session"
+    session.reset_context()
+    assert Session.get_current_session_id() is ""
+
+
+@pytest.mark.asyncio
+async def test_current_session():
+    session = Session("test-session")
+    assert Session.current() is None
+    async with session:
+        assert Session.current() == session
+    assert Session.current() is None


### PR DESCRIPTION
## Description

This PR make the following changes to the `Session` implementation.

- Agent invocation on `Runtime` is `asyncio` friendly and makes sure invocations run in coroutines concurrently while making sure invocations for the same session runs serially
- Refactoring and cleaning up `Session` implementation
- Add unit tests to bring code coverage of `Session` class to 100%
- Some APIs in Session have been changed and previous ones have been marked as deprecated (but still works)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update
- [ ] CI/CD update
- [ ] Other (please describe):

## Changes Made

- Cache keys defined in `Session` have been replaced with the enumeration `Session.Keys`
- `Session.get_current_session_id()` has been replaced with `Session.current()` that returns the current session directly
- `Session` now includes a proper `repr`
- `Session` can now support entry/exit semantics for `async with` that mark it as the current session for the coroutine and also acquire an async lock to force serial execution of coroutines related to the same session.
- `Session.get_all_keys()` has been replaced by the producer `Session.get_all()` that support filtering of session data objects by durability and volatility making it easier for storage implementations as they do not have to check session data object keys and filter accordingly.
- Current session API based on `Session.set_context()` and `Session.reset_context()` has been deprecated in favor of `async with` entry/exit semantics.
- `AgentService.run_multi()` has been modified to just call `Runtime.run()` without session locking. Volatile cache clearing and storage updating has also been removed. These steps not execute within `Runtime.run()`.

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [ ] Manual testing completed
- [x] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
