### PR TITLE
feat: add sensitive flag to openai_api_key terraform variable (#AK-58)

### DIFF
--- a/agent/deploy/variables.tf
+++ b/agent/deploy/variables.tf
@@ -27,6 +27,7 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }
 
 variable "langfuse_secret_key" {

--- a/examples/api/multimodal/dynamodb/deploy/variables.tf
+++ b/examples/api/multimodal/dynamodb/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/api/multimodal/redis/deploy/variables.tf
+++ b/examples/api/multimodal/redis/deploy/variables.tf
@@ -27,5 +27,6 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }
 

--- a/examples/aws-containerized/adk/deploy/variables.tf
+++ b/examples/aws-containerized/adk/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-containerized/crewai-auth/deploy/variables.tf
+++ b/examples/aws-containerized/crewai-auth/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-containerized/crewai/deploy/variables.tf
+++ b/examples/aws-containerized/crewai/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-containerized/mcp/multi/deploy/variables.tf
+++ b/examples/aws-containerized/mcp/multi/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-containerized/openai-dynamodb/deploy/variables.tf
+++ b/examples/aws-containerized/openai-dynamodb/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-serverless/adk/deploy/variables.tf
+++ b/examples/aws-serverless/adk/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-serverless/crewai/deploy/variables.tf
+++ b/examples/aws-serverless/crewai/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-serverless/langgraph/deploy/variables.tf
+++ b/examples/aws-serverless/langgraph/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-serverless/openai-auth/deploy/variables.tf
+++ b/examples/aws-serverless/openai-auth/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-serverless/openai/deploy/variables.tf
+++ b/examples/aws-serverless/openai/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/aws-serverless/scalable-openai/deploy/variables.tf
+++ b/examples/aws-serverless/scalable-openai/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/azure-containerized/openai-cosmos/deploy/variables.tf
+++ b/examples/azure-containerized/openai-cosmos/deploy/variables.tf
@@ -42,5 +42,6 @@ variable "environment_variables" {
 
 variable "openai_api_key" {
   type        = string
+  sensitive   = true
   description = "The OpenAI API key"
 }

--- a/examples/azure-serverless/openai/deploy/variables.tf
+++ b/examples/azure-serverless/openai/deploy/variables.tf
@@ -21,6 +21,7 @@ variable "module_name" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }
 
 variable "publisher_email" {

--- a/examples/memory/cosmos/deploy/variables.tf
+++ b/examples/memory/cosmos/deploy/variables.tf
@@ -21,6 +21,7 @@ variable "module_name" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }
 
 variable "publisher_email" {

--- a/examples/memory/dynamodb/deploy/variables.tf
+++ b/examples/memory/dynamodb/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }

--- a/examples/memory/redis/deploy/variables.tf
+++ b/examples/memory/redis/deploy/variables.tf
@@ -27,4 +27,5 @@ variable "is_production" {
 variable "openai_api_key" {
   description = "OpenAI API Key"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
## Description
Add `sensitive = true` flag to the `openai_api_key` Terraform variable across all deployment examples to prevent the API key from being exposed in Terraform plan/apply output and state files.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Related Issues
Relates to #58

## Changes Made
- Added `sensitive = true` to the `openai_api_key` variable declaration in 19 `variables.tf` files across AWS, Azure, and agent deployment examples

## Testing
- This is a Terraform variable flag change, no functional logic was modified so no testing is required

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes
The `sensitive = true` flag masks the OpenAI API key in Terraform CLI output and prevents it from being shown in plain text in state files.
