### PR TITLE
fix: api_version getting updated incorrectly in examples

### DIFF
--- a/examples/aws-serverless/openai-auth/deploy/main.tf
+++ b/examples/aws-serverless/openai-auth/deploy/main.tf
@@ -18,7 +18,7 @@ module "serverless_agents" {
   region               = var.region
 
   # To override the default API version, API base path, and agent endpoint
-  # api_version    = "0.4.0"
+  # api_version    = "v1"
   # api_base_path  = "api-new"
   # agent_endpoint = "chat-new"
 

--- a/examples/aws-serverless/openai/deploy/main.tf
+++ b/examples/aws-serverless/openai/deploy/main.tf
@@ -18,7 +18,7 @@ module "serverless_agents" {
   region               = var.region
 
   # To override the default API version, API base path, and agent endpoint
-  # api_version    = "0.4.0"
+  # api_version    = "v1"
   # api_base_path  = "api-new"
   # agent_endpoint = "chat-new"
 

--- a/examples/aws-serverless/scalable-openai/deploy/main.tf
+++ b/examples/aws-serverless/scalable-openai/deploy/main.tf
@@ -30,7 +30,7 @@ module "serverless_agents" {
   create_dynamodb_response_store = true
 
   # API Gateway configuration
-  api_version    = "0.4.0"
+  api_version    = "v1"
   api_base_path  = "api"
   agent_endpoint = "chat"
 

--- a/examples/azure-containerized/openai-cosmos/deploy/main.tf
+++ b/examples/azure-containerized/openai-cosmos/deploy/main.tf
@@ -13,7 +13,6 @@ module "containerd_agent" {
   container_port              = 8000
   container_health_check_path = "/health"
 
-  # api_version             = "0.4.0"
   is_production           = false
   create_redis_cluster    = false
   create_cosmosdb_cluster = true

--- a/scripts/test_update_terraform_versions.py
+++ b/scripts/test_update_terraform_versions.py
@@ -250,6 +250,56 @@ module docker_image {
         temp_path.unlink()
 
 
+def test_api_version_not_updated():
+    """Test that api_version parameter is not updated, only module version."""
+    content = '''
+module "serverless_agents" {
+  source = "yaalalabs/ak-serverless/aws"
+  version = "0.4.0"
+
+  product_alias        = var.product_alias
+  env_alias            = var.env_alias
+  function_description = "Agent Kernel OpenAI Sample Lambda"
+  function_name        = "openai-agents"
+  handler_path         = "lambda.handler"
+  module_name          = var.module_name
+  package_path         = "../dist"
+  package_type         = "Image"
+  memory_size          = 256
+  create_redis_cluster = true
+  product_display_name = "AK OpenAI Serverless Example"
+  region               = var.region
+
+  # API Gateway configuration
+  api_version    = "0.4.0"
+  api_base_path  = "api"
+  agent_endpoint = "chat"
+}
+'''
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.tf', delete=False) as f:
+        f.write(content)
+        f.flush()
+        temp_path = Path(f.name)
+    
+    try:
+        was_modified, num_updates = update_terraform_versions(temp_path, "0.5.0")
+        
+        assert was_modified, "File should be modified"
+        assert num_updates == 1, f"Expected 1 update, got {num_updates}"
+        
+        with open(temp_path, 'r') as f:
+            result = f.read()
+        
+        # Module version should be updated
+        assert 'version = "0.5.0"' in result
+        # api_version should NOT be updated
+        assert 'api_version    = "0.4.0"' in result
+        print("✅ test_api_version_not_updated passed")
+    finally:
+        temp_path.unlink()
+
+
 if __name__ == "__main__":
     print("Running tests for update_terraform_versions.py...\n")
     
@@ -260,5 +310,6 @@ if __name__ == "__main__":
     test_no_changes_when_no_modules()
     test_update_module_with_count_first()
     test_update_module_without_quotes()
+    test_api_version_not_updated()
     
     print("\n✅ All tests passed!")

--- a/scripts/update_examples_version.py
+++ b/scripts/update_examples_version.py
@@ -78,7 +78,7 @@ def regenerate_uv_lock(project_dir: Path, dry_run: bool = False, retries: int = 
     for attempt in range(retries):
         try:
             # Run uv lock in the project directory
-            result = subprocess.run(
+            subprocess.run(
                 ["uv", "lock"],
                 cwd=project_dir,
                 check=True,
@@ -110,7 +110,7 @@ def regenerate_uv_lock(project_dir: Path, dry_run: bool = False, retries: int = 
                 continue
             
         except subprocess.TimeoutExpired:
-            last_error = f"uv lock timed out after 15 seconds"
+            last_error = "uv lock timed out after 15 seconds"
             if attempt < retries - 1:
                 print(f"  ⚠ Attempt {attempt + 1}/{retries} timed out.")
                 print(f"  ⏳ Waiting {retry_delay}s before retry...")
@@ -207,7 +207,7 @@ def main():
     if args.version:
         print(f"Updating agentkernel version to: {args.version}")
     else:
-        print(f"Regenerating lock files without version update")
+        print("Regenerating lock files without version update")
     print()
 
     modified_count = 0
@@ -228,12 +228,12 @@ def main():
                 for match in matches:
                     print(f"  - {match}>=... → {match}>={args.version}")
                 if not args.skip_lock:
-                    print(f"  - Would regenerate uv.lock")
+                    print("  - Would regenerate uv.lock")
                 modified_count += 1
             elif not args.version and args.force_lock:
                 print(f"Would regenerate lock: {relative_path}")
                 if not args.skip_lock:
-                    print(f"  - Would regenerate uv.lock")
+                    print("  - Would regenerate uv.lock")
         else:
             was_modified = False
             if args.version:
@@ -245,23 +245,23 @@ def main():
 
                 # Regenerate uv.lock file
                 if not args.skip_lock:
-                    print(f"  Regenerating uv.lock...")
+                    print("  Regenerating uv.lock...")
                     if regenerate_uv_lock(project_dir, args.dry_run, args.lock_retries, args.lock_retry_delay):
-                        print(f"  ✓ Lock file regenerated")
+                        print("  ✓ Lock file regenerated")
                         lock_success_count += 1
                     else:
-                        print(f"  ✗ Failed to regenerate lock file")
+                        print("  ✗ Failed to regenerate lock file")
                         lock_fail_count += 1
             else:
                 # File wasn't modified but we might need to force lock regeneration
                 if args.force_lock and not args.skip_lock:
                     print(f"  {relative_path} (no version change, regenerating lock)")
-                    print(f"  Regenerating uv.lock...")
+                    print("  Regenerating uv.lock...")
                     if regenerate_uv_lock(project_dir, args.dry_run, args.lock_retries, args.lock_retry_delay):
-                        print(f"  ✓ Lock file regenerated")
+                        print("  ✓ Lock file regenerated")
                         lock_success_count += 1
                     else:
-                        print(f"  ✗ Failed to regenerate lock file")
+                        print("  ✗ Failed to regenerate lock file")
                         lock_fail_count += 1
                 else:
                     if args.version:
@@ -272,7 +272,7 @@ def main():
         if args.version:
             print(f"Dry run complete. {modified_count} file(s) would be modified.")
         else:
-            print(f"Dry run complete. Lock files would be regenerated for all examples.")
+            print("Dry run complete. Lock files would be regenerated for all examples.")
     else:
         if args.version:
             print(f"Updated {modified_count} file(s).")

--- a/scripts/update_terraform_versions.py
+++ b/scripts/update_terraform_versions.py
@@ -63,7 +63,7 @@ def update_terraform_versions(file_path: Path, new_version: str) -> Tuple[bool, 
             return module_block
         
         # Check if this module has a version attribute
-        version_pattern = r'(version\s*=\s*)"[^"]+"'
+        version_pattern = r'(\bversion\s*=\s*)"[^"]+"'
         if not re.search(version_pattern, module_block):
             # No version attribute, return unchanged
             return module_block
@@ -145,7 +145,7 @@ def main():
             with open(tf_file, 'r') as f:
                 content = f.read()
             pattern = re.compile(
-                r'source\s*=\s*"(?:app\.terraform\.io/|registry\.terraform\.io/)?yaalalabs/ak-[^"]+"\s*\n\s*version\s*=\s*"[^"]+"',
+                r'source\s*=\s*"(?:app\.terraform\.io/|registry\.terraform\.io/)?yaalalabs/ak-[^"]+"\s*\n\s*\bversion\s*=\s*"[^"]+"',
                 re.MULTILINE
             )
             matches = pattern.findall(content)


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
**Issue**
Theapi_version in the examples/.../main.tf files are being updated automatically by the github actions agent-kernel-ci[bot]

**RCA**
The script being triggered by the GitHub action is supposed to update the versions of Terraform modules according to their pattern, this pattern may be incorrect, causing the script to update the api_version param in the examples/…/main.tf files

**Fix**
Updated the relevant scripts and the examples having this issue

## Type of Change
<!-- Mark the relevant option with an "x" -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] CI/CD update
- [ ] Other (please describe):