### PR TITLE
Potential fix for code scanning alert no. 52: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/test-reusable.yaml
+++ b/.github/workflows/test-reusable.yaml
@@ -83,7 +83,7 @@ jobs:
         run: ./build.sh
 
       - name: Cache ak-py build
-        if: ${{ inputs.enable_cache }}
+        if: ${{ inputs.enable_cache && inputs.checkout_ref == github.sha }}
         uses: actions/cache/save@v4
         with:
           path: ak-py/dist
@@ -138,7 +138,7 @@ jobs:
         run: pip install uv
 
       - name: Restore ak-py build
-        if: ${{ inputs.enable_cache }}
+        if: ${{ inputs.enable_cache && inputs.checkout_ref == github.sha }}
         uses: actions/cache/restore@v4
         with:
           path: ak-py/dist


### PR DESCRIPTION
Potential fix for [https://github.com/yaalalabs/agent-kernel/security/code-scanning/52](https://github.com/yaalalabs/agent-kernel/security/code-scanning/52)

Best fix: **disable cache operations when the checked-out ref is untrusted**, while preserving existing behavior for trusted refs.  
In this snippet, the safest minimal change is to gate both cache save and restore so they only run when `inputs.checkout_ref` equals the immutable workflow commit (`github.sha`) and caching is enabled. This prevents cache interactions for caller-supplied arbitrary refs (typical untrusted PR head refs), eliminating the poisoning path without changing test/build behavior.

Concretely in `.github/workflows/test-reusable.yaml`:
- Update the `if` condition on:
  - `Cache ak-py build` step (currently line ~86)
  - `Restore ak-py build` step (currently line ~141)
- New condition should require both:
  - `inputs.enable_cache` is true, and
  - `inputs.checkout_ref == github.sha`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
