### PR TITLE
fix: ecs health check grace period. if this is not set

### DIFF
--- a/ak-deployment/ak-aws/containerized/README.md
+++ b/ak-deployment/ak-aws/containerized/README.md
@@ -195,6 +195,7 @@ rest_service = {
   desired_count         = 1            # Number of tasks
   container_port        = 8000         # Container port
   health_check_endpoint = "/health"    # Health check path
+  health_check_grace_period_seconds = 120 # ECS ignores ALB unhealthy signals for this long after task start
   image_uri             = null         # Pre-built image URI (alternative to package_path)
   command               = null         # Override Docker CMD
   environment_variables = {}           # Service-specific env vars

--- a/ak-deployment/ak-aws/containerized/modules/README.md
+++ b/ak-deployment/ak-aws/containerized/modules/README.md
@@ -117,14 +117,15 @@ queue_config = {
 
 ```hcl
 rest_service = {
-  cpu                   = 256
-  memory                = 512
-  desired_count         = 1
-  container_port        = 8000
-  health_check_endpoint = "/health"
-  image_uri             = "..."
-  command               = ["python", "app.py"]
-  environment_variables = {}
+  cpu                                = 256
+  memory                             = 512
+  desired_count                      = 1
+  container_port                     = 8000
+  health_check_endpoint              = "/health"
+  health_check_grace_period_seconds  = 120
+  image_uri                          = "..."
+  command                            = ["python", "app.py"]
+  environment_variables              = {}
 }
 ```
 

--- a/ak-deployment/ak-aws/containerized/modules/rest-service/main.tf
+++ b/ak-deployment/ak-aws/containerized/modules/rest-service/main.tf
@@ -160,6 +160,8 @@ module "ecs_service" {
   subnet_ids         = var.subnet_ids
   security_group_ids = [aws_security_group.ecs_service.id]
 
+  health_check_grace_period_seconds = var.rest_service.health_check_grace_period_seconds
+
   load_balancer = {
     service = {
       target_group_arn = aws_lb_target_group.app.arn

--- a/ak-deployment/ak-aws/containerized/modules/rest-service/variables.tf
+++ b/ak-deployment/ak-aws/containerized/modules/rest-service/variables.tf
@@ -86,14 +86,15 @@ variable "dynamodb_memory_table_name" {
 variable "rest_service" {
   description = "REST service configuration object"
   type = object({
-    cpu                   = optional(number, 256)
-    memory                = optional(number, 512)
-    desired_count         = optional(number, 1)
-    container_port        = optional(number, 8000)
-    health_check_endpoint = optional(string, "/health")
-    image_uri             = string
-    command               = optional(list(string), null)
-    environment_variables = optional(map(string), {})
+    cpu                               = optional(number, 256)
+    memory                            = optional(number, 512)
+    desired_count                     = optional(number, 1)
+    container_port                    = optional(number, 8000)
+    health_check_endpoint             = optional(string, "/health")
+    health_check_grace_period_seconds = optional(number, 120)
+    image_uri                         = string
+    command                           = optional(list(string), null)
+    environment_variables             = optional(map(string), {})
   })
 }
 

--- a/ak-deployment/ak-aws/containerized/rest_service.tf
+++ b/ak-deployment/ak-aws/containerized/rest_service.tf
@@ -26,14 +26,15 @@ module "rest_service" {
   dynamodb_memory_table_name   = local.dynamodb_memory_table_name
 
   rest_service = {
-    cpu                   = var.rest_service.cpu
-    memory                = var.rest_service.memory
-    desired_count         = var.rest_service.desired_count
-    container_port        = var.rest_service.container_port
-    health_check_endpoint = var.rest_service.health_check_endpoint
-    image_uri             = var.rest_service.image_uri != null ? var.rest_service.image_uri : module.docker_image[0].docker_image_uri
-    command               = var.rest_service.command
-    environment_variables = merge(var.environment_variables, var.rest_service.environment_variables)
+    cpu                               = var.rest_service.cpu
+    memory                            = var.rest_service.memory
+    desired_count                     = var.rest_service.desired_count
+    container_port                    = var.rest_service.container_port
+    health_check_endpoint             = var.rest_service.health_check_endpoint
+    health_check_grace_period_seconds = var.rest_service.health_check_grace_period_seconds
+    image_uri                         = var.rest_service.image_uri != null ? var.rest_service.image_uri : module.docker_image[0].docker_image_uri
+    command                           = var.rest_service.command
+    environment_variables             = merge(var.environment_variables, var.rest_service.environment_variables)
   }
 
   queue_mode                = var.queue_mode

--- a/ak-deployment/ak-aws/containerized/variables.tf
+++ b/ak-deployment/ak-aws/containerized/variables.tf
@@ -135,10 +135,11 @@ variable "rest_service" {
     desired_count         = optional(number, 1)
     container_port        = optional(number, 8000)
     health_check_endpoint = optional(string, "/health")
-    package_path          = string                 # Docker image source path (required)
-    image_uri             = optional(string, null) # Or provide pre-built image URI
-    command               = optional(list(string), null)
-    environment_variables = optional(map(string), {})
+    health_check_grace_period_seconds = optional(number, 120)
+    package_path                      = string                 # Docker image source path (required)
+    image_uri                         = optional(string, null) # Or provide pre-built image URI
+    command                           = optional(list(string), null)
+    environment_variables             = optional(map(string), {})
   })
 }
 


### PR DESCRIPTION
## Description

The `rest_service` module never exposed or wired through an ECS health check grace period, so ECS always used its default grace period of `0`. On slower-starting containers, the ALB could mark a task unhealthy (and ECS would kill it) before the app finished booting, causing avoidable task churn during deploys/restarts.

This adds a configurable `health_check_grace_period_seconds` (default `120`) and threads it through to the `ecs_service` module's health check grace period setting.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #

## Changes Made

- Add `health_check_grace_period_seconds` (default `120`) to the `rest_service` variable object in both `containerized/variables.tf` and `modules/rest-service/variables.tf`
- Pass `health_check_grace_period_seconds` through `rest_service.tf` into the `rest_service` module call
- Wire `health_check_grace_period_seconds` into the `ecs_service` module invocation in `modules/rest-service/main.tf`
- Document the new variable in `containerized/README.md` and `modules/README.md`

## Testing

- [x] Manual testing completed (terraform plan/fmt on affected modules)
- [ ] Unit tests pass locally
- [ ] Integration tests pass locally
- [ ] New tests added for changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This is a Terraform-only change under `ak-deployment/ak-aws/containerized/`; no application code changed.
