### PR TITLE
feat: add provider-agnostic support for AWS and Google modules

### DIFF
--- a/ak-deployment/ak-aws/containerized/README.md
+++ b/ak-deployment/ak-aws/containerized/README.md
@@ -6,6 +6,7 @@ Scalable, production-ready deployment of Agent Kernel on AWS using ECS Fargate w
 
 - [Overview](#overview)
 - [Architecture](#architecture)
+- [Providers](#providers)
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
 - [Deployment Modes](#deployment-modes)
@@ -96,8 +97,9 @@ The REST service handles HTTP requests while Agent Runner processes the actual a
 
 ```hcl
 module "containerized_agents" {
-  source  = "yaalalabs/ak-containerized/aws"
-  version = "0.6.0"
+  source    = "yaalalabs/ak-containerized/aws"
+  version   = "0.8.0"
+  providers = { aws = aws, docker = docker }
 
   product_alias = "my-agent"
   env_alias     = "dev"
@@ -125,8 +127,9 @@ module "containerized_agents" {
 
 ```hcl
 module "containerized_agents" {
-  source  = "yaalalabs/ak-containerized/aws"
-  version = "0.6.0"
+  source    = "yaalalabs/ak-containerized/aws"
+  version   = "0.8.0"
+  providers = { aws = aws, docker = docker }
 
   product_alias = "my-agent"
   env_alias     = "prod"
@@ -487,6 +490,36 @@ output "api_gateway_cloudwatch_log_group_name"  # API Gateway log group name (nu
 - **Terraform**: >= 1.9.5
 - **AWS Provider**: >= 6.11.0
 - **Docker Provider**: 3.6.2
+
+## Providers
+
+This module is provider-agnostic: it declares `aws` and `docker` in `required_providers` but does **not** configure them internally. Configure both providers in your root module and pass them explicitly via the `providers` argument. This is what lets you use `count`, `for_each`, or `depends_on` on the module block, and lets a minimal/standalone config destroy the resources it created.
+
+```hcl
+provider "aws" {
+  region = var.region
+}
+
+# Docker authenticates against ECR to push the images this module builds
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+module "containerized_agents" {
+  source    = "yaalalabs/ak-containerized/aws"
+  version   = "0.8.0"
+  providers = { aws = aws, docker = docker }
+
+  # ... other inputs
+}
+```
 
 ## Support
 

--- a/ak-deployment/ak-aws/containerized/main.tf
+++ b/ak-deployment/ak-aws/containerized/main.tf
@@ -1,5 +1,3 @@
-provider "aws" { region = var.region }
-
 terraform {
   required_providers {
     aws = {
@@ -12,12 +10,4 @@ terraform {
     }
   }
   required_version = ">= 1.9.5"
-}
-
-provider "docker" {
-  registry_auth {
-    address = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
-    username = data.aws_ecr_authorization_token.token.user_name
-    password = data.aws_ecr_authorization_token.token.password
-  }
 }

--- a/ak-deployment/ak-aws/containerized/variables.tf
+++ b/ak-deployment/ak-aws/containerized/variables.tf
@@ -130,11 +130,11 @@ variable "create_dynamodb_memory_table" {
 variable "rest_service" {
   description = "REST service configuration object"
   type = object({
-    cpu                   = optional(number, 256)
-    memory                = optional(number, 512)
-    desired_count         = optional(number, 1)
-    container_port        = optional(number, 8000)
-    health_check_endpoint = optional(string, "/health")
+    cpu                               = optional(number, 256)
+    memory                            = optional(number, 512)
+    desired_count                     = optional(number, 1)
+    container_port                    = optional(number, 8000)
+    health_check_endpoint             = optional(string, "/health")
     health_check_grace_period_seconds = optional(number, 120)
     package_path                      = string                 # Docker image source path (required)
     image_uri                         = optional(string, null) # Or provide pre-built image URI
@@ -222,7 +222,6 @@ variable "enable_mcp_server" {
   default     = false
 }
 
-data "aws_ecr_authorization_token" "token" {}
 data "aws_caller_identity" "current" {}
 
 # ---------------------------------------------------------------------------

--- a/ak-deployment/ak-aws/serverless/README.md
+++ b/ak-deployment/ak-aws/serverless/README.md
@@ -24,6 +24,37 @@ Perfect for microservices, API backends, event-driven architectures, and serverl
 |------|---------|
 | Terraform | >= 1.9.5 |
 | AWS Provider | >= 6.11.0 |
+| Docker Provider | 3.6.2 |
+
+## 🔌 Providers
+
+This module is provider-agnostic: it declares `aws` and `docker` in `required_providers` but does **not** configure them internally. Configure both providers in your root module and pass them explicitly via the `providers` argument. This is what lets you use `count`, `for_each`, or `depends_on` on the module block, and lets a minimal/standalone config destroy the resources it created.
+
+```hcl
+provider "aws" {
+  region = var.region
+}
+
+# Docker authenticates against ECR to push the images this module builds
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+module "python_api" {
+  source    = "yaalalabs/ak-serverless/aws"
+  version   = "0.8.0"
+  providers = { aws = aws, docker = docker }
+
+  # ... other inputs, see below
+}
+```
 
 ## 🚀 Usage
 
@@ -31,7 +62,8 @@ Perfect for microservices, API backends, event-driven architectures, and serverl
 
 ```hcl
 module "python_api" {
-  source = "yaalalabs/ak-serverless/aws"
+  source    = "yaalalabs/ak-serverless/aws"
+  providers = { aws = aws, docker = docker }
 
   region              = "us-west-2"
   product_alias       = "myapp"

--- a/ak-deployment/ak-aws/serverless/main.tf
+++ b/ak-deployment/ak-aws/serverless/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = var.region
-}
-
 terraform {
   required_providers {
     aws = {
@@ -14,12 +10,4 @@ terraform {
     }
   }
   required_version = ">= 1.9.5" # pin terraform version
-}
-
-provider "docker" {
-  registry_auth {
-    address = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
-    username = data.aws_ecr_authorization_token.token.user_name
-    password = data.aws_ecr_authorization_token.token.password
-  }
 }

--- a/ak-deployment/ak-aws/serverless/state.tf
+++ b/ak-deployment/ak-aws/serverless/state.tf
@@ -3,10 +3,6 @@ data "aws_vpc" "provided" {
   id    = var.vpc_id
 }
 
-data "aws_caller_identity" "current" {}
-
-data "aws_ecr_authorization_token" "token" {}
-
 locals {
   lambda_kms_key_arn                    = null
   cloudwatch_kms_key_arn                = null
@@ -24,24 +20,24 @@ locals {
   dynamodb_multimodal_memory_table_arn  = var.create_dynamodb_multimodal_memory_table == true ? module.dynamodb_multimodal_memory[0].table_arn : null
   dynamodb_multimodal_memory_table_name = var.create_dynamodb_multimodal_memory_table == true ? module.dynamodb_multimodal_memory[0].table_name : null
 
-  request_handler_enabled               = var.enable_api_gateway
-  request_handler_lambda_function_name  = local.request_handler_enabled ? module.request_handler[0].lambda_function_name : null
-  request_handler_lambda_invoke_arn     = local.request_handler_enabled ? module.request_handler[0].lambda_function_invoke_arn : null
-  request_handler_lambda_role_arn       = local.request_handler_enabled ? module.request_handler[0].lambda_role_arn : null
+  request_handler_enabled              = var.enable_api_gateway
+  request_handler_lambda_function_name = local.request_handler_enabled ? module.request_handler[0].lambda_function_name : null
+  request_handler_lambda_invoke_arn    = local.request_handler_enabled ? module.request_handler[0].lambda_function_invoke_arn : null
+  request_handler_lambda_role_arn      = local.request_handler_enabled ? module.request_handler[0].lambda_role_arn : null
 
-  is_websocket_mode = contains(["async", "stream"], var.execution_mode) # True for both "async" (full-response WS) and "stream" (chunk-per-message WS)
-  websocket_api_enabled                  = var.enable_api_gateway && local.is_websocket_mode
-  rest_api_enabled                       = var.enable_api_gateway && !local.is_websocket_mode
+  is_websocket_mode     = contains(["async", "stream"], var.execution_mode) # True for both "async" (full-response WS) and "stream" (chunk-per-message WS)
+  websocket_api_enabled = var.enable_api_gateway && local.is_websocket_mode
+  rest_api_enabled      = var.enable_api_gateway && !local.is_websocket_mode
 
-  create_authorizer                     = var.enable_api_gateway && var.authorizer != null ? (var.authorizer.function_name != null && var.authorizer.handler_path != null && var.authorizer.package_type != null && var.authorizer.package_path != null && var.authorizer.module_name != null) : false
+  create_authorizer = var.enable_api_gateway && var.authorizer != null ? (var.authorizer.function_name != null && var.authorizer.handler_path != null && var.authorizer.package_type != null && var.authorizer.package_path != null && var.authorizer.module_name != null) : false
   # Authorizer status message for logging
   authorizer_required_vars_text = join(", ", compact(["function_name", "handler_path", "package_type", "package_path", "module_name"]))
   authorizer_status_message     = !var.enable_api_gateway ? "Did NOT create Authorizer Lambda: enable_api_gateway is false." : (local.create_authorizer ? format("Created Authorizer Lambda: All required variables are present (%s)", local.authorizer_required_vars_text) : format("Did NOT create Authorizer Lambda: Missing one or more required variables (%s)", local.authorizer_required_vars_text))
 
   # Effective response store creation flags (disabled for websocket modes — endpoint_url in SQS message is used instead)
   create_dynamodb_response_store_effective = var.create_dynamodb_response_store && !local.is_websocket_mode
-  create_redis_response_store_effective     = var.create_redis_response_store && !local.is_websocket_mode
-  create_valkey_response_store_effective    = var.create_valkey_response_store && !local.is_websocket_mode
+  create_redis_response_store_effective    = var.create_redis_response_store && !local.is_websocket_mode
+  create_valkey_response_store_effective   = var.create_valkey_response_store && !local.is_websocket_mode
 
   response_store_dynamodb_table_name = local.create_dynamodb_response_store_effective ? module.dynamodb_response_store[0].table_name : null
   response_store_dynamodb_table_arn  = local.create_dynamodb_response_store_effective ? module.dynamodb_response_store[0].table_arn : null
@@ -58,11 +54,11 @@ locals {
     url = local.response_store_valkey_url
   } : null
 
-  input_queue_url                = var.queue_mode ? module.queues[0].input_queue_url : null
-  input_queue_arn                = var.queue_mode ? module.queues[0].input_queue_arn : null
-  input_queue_visibility_timeout = var.queue_mode ? var.queue_config.input_queue_visibility_timeout : null
-  output_queue_url               = var.queue_mode ? module.queues[0].output_queue_url : null
-  output_queue_arn               = var.queue_mode ? module.queues[0].output_queue_arn : null
+  input_queue_url                 = var.queue_mode ? module.queues[0].input_queue_url : null
+  input_queue_arn                 = var.queue_mode ? module.queues[0].input_queue_arn : null
+  input_queue_visibility_timeout  = var.queue_mode ? var.queue_config.input_queue_visibility_timeout : null
+  output_queue_url                = var.queue_mode ? module.queues[0].output_queue_url : null
+  output_queue_arn                = var.queue_mode ? module.queues[0].output_queue_arn : null
   output_queue_visibility_timeout = var.queue_mode ? var.queue_config.output_queue_visibility_timeout : null
 
   chat_endpoint = concat(
@@ -361,8 +357,8 @@ check "queue_visibility_timeouts" {
 }
 
 module "websocket_connections" {
-  count  = local.websocket_api_enabled ? 1 : 0
-  source = "yaalalabs/ak-common/aws//modules/dynamodb"
+  count   = local.websocket_api_enabled ? 1 : 0
+  source  = "yaalalabs/ak-common/aws//modules/dynamodb"
   version = "0.8.0"
   attributes = [
     { name = "user_id", type = "S" },
@@ -439,46 +435,46 @@ module "request_handler" {
   count  = local.request_handler_enabled ? 1 : 0
   source = "./modules/request-handler"
 
-  region                                  = var.region
-  product_alias                           = var.product_alias
-  product_display_name                    = var.product_display_name
-  env_alias                               = var.env_alias
-  module_type                             = var.module_type
-  module_name                             = var.request_handler.module_name
-  api_version                             = var.api_version
-  agent_endpoint                          = var.agent_endpoint
-  api_base_path                           = var.api_base_path
-  vpc_id                                  = local.vpc_id
-  subnet_ids                              = local.subnet_ids
-  security_group_id                       = local.security_group_id
-  lambda_signer_profile_name              = local.lambda_signer_profile_name
-  lambda_signing_config_arn               = local.lambda_signing_config_arn
-  lambda_kms_key_arn                      = local.lambda_kms_key_arn
-  cloudwatch_kms_key_arn                  = local.cloudwatch_kms_key_arn
-  is_production                           = var.is_production
-  response_store_redis                    = local.response_handler_response_store_redis
-  response_store_valkey                   = local.response_handler_response_store_valkey
-  response_store_dynamodb                 = local.response_handler_response_store_dynamodb
-  package_path                            = var.request_handler.package_path
-  cloudwatch_logs_retention_in_days       = var.request_handler.cloudwatch_logs_retention_in_days
-  queue_mode                              = var.queue_mode
-  event_source_mapping                    = var.request_handler.event_source_mapping
-  timeout                                 = var.request_handler.timeout
-  memory_size                             = var.request_handler.memory_size
-  function_name                           = var.request_handler.function_name
-  function_description                    = var.request_handler.function_description
-  handler_path                            = var.request_handler.handler_path
-  package_type                            = var.request_handler.package_type
-  layers                                  = var.request_handler.layers
-  source_bucket                           = local.shared_source_bucket
-  source_key                              = try(module.request_handler_source_package[0].s3_key, null)
-  source_version_id                       = try(module.request_handler_source_package[0].s3_object_version, null)
+  region                            = var.region
+  product_alias                     = var.product_alias
+  product_display_name              = var.product_display_name
+  env_alias                         = var.env_alias
+  module_type                       = var.module_type
+  module_name                       = var.request_handler.module_name
+  api_version                       = var.api_version
+  agent_endpoint                    = var.agent_endpoint
+  api_base_path                     = var.api_base_path
+  vpc_id                            = local.vpc_id
+  subnet_ids                        = local.subnet_ids
+  security_group_id                 = local.security_group_id
+  lambda_signer_profile_name        = local.lambda_signer_profile_name
+  lambda_signing_config_arn         = local.lambda_signing_config_arn
+  lambda_kms_key_arn                = local.lambda_kms_key_arn
+  cloudwatch_kms_key_arn            = local.cloudwatch_kms_key_arn
+  is_production                     = var.is_production
+  response_store_redis              = local.response_handler_response_store_redis
+  response_store_valkey             = local.response_handler_response_store_valkey
+  response_store_dynamodb           = local.response_handler_response_store_dynamodb
+  package_path                      = var.request_handler.package_path
+  cloudwatch_logs_retention_in_days = var.request_handler.cloudwatch_logs_retention_in_days
+  queue_mode                        = var.queue_mode
+  event_source_mapping              = var.request_handler.event_source_mapping
+  timeout                           = var.request_handler.timeout
+  memory_size                       = var.request_handler.memory_size
+  function_name                     = var.request_handler.function_name
+  function_description              = var.request_handler.function_description
+  handler_path                      = var.request_handler.handler_path
+  package_type                      = var.request_handler.package_type
+  layers                            = var.request_handler.layers
+  source_bucket                     = local.shared_source_bucket
+  source_key                        = try(module.request_handler_source_package[0].s3_key, null)
+  source_version_id                 = try(module.request_handler_source_package[0].s3_object_version, null)
   s3_existing_package = var.request_handler.package_type == "S3Zip" ? (
     try(var.request_handler.lambda_package_s3, null) != null ? {
       bucket     = var.request_handler.lambda_package_s3.bucket
       key        = var.request_handler.lambda_package_s3.key
       version_id = try(var.request_handler.lambda_package_s3.version_id, null)
-    } : {
+      } : {
       bucket     = local.shared_source_bucket
       key        = module.request_handler_source_package[0].s3_key
       version_id = module.request_handler_source_package[0].s3_object_version
@@ -529,24 +525,24 @@ module "agent_runner" {
       bucket     = var.agent_runner.lambda_package_s3.bucket
       key        = var.agent_runner.lambda_package_s3.key
       version_id = try(var.agent_runner.lambda_package_s3.version_id, null)
-    } : {
+      } : {
       bucket     = local.shared_source_bucket
       key        = module.agent_runner_source_package[0].s3_key
       version_id = module.agent_runner_source_package[0].s3_object_version
     }
   ) : null
-  docker_image_uri              = var.agent_runner.package_type == "Image" ? (try(var.agent_runner.ecr_image_uri, null) != null ? var.agent_runner.ecr_image_uri : module.agent_runner_docker_image[0].docker_image_uri) : null
-  is_production                 = var.is_production
-  lambda_signer_profile_name    = local.lambda_signer_profile_name
-  lambda_signing_config_arn     = local.lambda_signing_config_arn
-  create_dynamodb_memory_table  = var.create_dynamodb_memory_table
+  docker_image_uri                        = var.agent_runner.package_type == "Image" ? (try(var.agent_runner.ecr_image_uri, null) != null ? var.agent_runner.ecr_image_uri : module.agent_runner_docker_image[0].docker_image_uri) : null
+  is_production                           = var.is_production
+  lambda_signer_profile_name              = local.lambda_signer_profile_name
+  lambda_signing_config_arn               = local.lambda_signing_config_arn
+  create_dynamodb_memory_table            = var.create_dynamodb_memory_table
   create_dynamodb_multimodal_memory_table = var.create_dynamodb_multimodal_memory_table
-  dynamodb_memory_table_arn     = local.dynamodb_memory_table_arn
-  dynamodb_memory_table_name    = local.dynamodb_memory_table_name
-  dynamodb_multimodal_memory_table_arn  = local.dynamodb_multimodal_memory_table_arn
-  dynamodb_multimodal_memory_table_name = local.dynamodb_multimodal_memory_table_name
-  redis_url                     = local.redis_url
-  valkey_url                    = local.valkey_url
+  dynamodb_memory_table_arn               = local.dynamodb_memory_table_arn
+  dynamodb_memory_table_name              = local.dynamodb_memory_table_name
+  dynamodb_multimodal_memory_table_arn    = local.dynamodb_multimodal_memory_table_arn
+  dynamodb_multimodal_memory_table_name   = local.dynamodb_multimodal_memory_table_name
+  redis_url                               = local.redis_url
+  valkey_url                              = local.valkey_url
 
   queue_config = {
     input_queue_arn                    = local.input_queue_arn
@@ -587,7 +583,7 @@ module "response_handler" {
       bucket     = var.response_handler.lambda_package_s3.bucket
       key        = var.response_handler.lambda_package_s3.key
       version_id = try(var.response_handler.lambda_package_s3.version_id, null)
-    } : {
+      } : {
       bucket     = local.shared_source_bucket
       key        = module.response_handler_source_package[0].s3_key
       version_id = module.response_handler_source_package[0].s3_object_version
@@ -595,7 +591,7 @@ module "response_handler" {
   ) : null
   docker_image_uri = var.response_handler.package_type == "Image" ? (
     try(var.response_handler.ecr_image_uri, null) != null ? var.response_handler.ecr_image_uri : module.response_handler_docker_image[0].docker_image_uri
-  ): null
+  ) : null
   response_handler = merge(var.response_handler, {
     environment_variables = merge(var.response_handler.environment_variables, var.execution_mode != null ? { AK_EXECUTION__MODE = var.execution_mode } : {})
   })

--- a/ak-deployment/ak-azure/common/versions.tf
+++ b/ak-deployment/ak-azure/common/versions.tf
@@ -5,14 +5,5 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 4.57.0, < 5.0.0"
     }
-    docker = {
-      source  = "kreuzwerker/docker"
-      version = "3.6.2"
-    }
   }
-}
-
-provider "azurerm" {
-  features {}
-  resource_provider_registrations = ["Microsoft.App"]
 }

--- a/ak-deployment/ak-azure/containerized/README.md
+++ b/ak-deployment/ak-azure/containerized/README.md
@@ -21,7 +21,27 @@ Perfect for microservices, web applications, APIs requiring persistent connectio
 |------|---------|
 | Terraform | >= 1.9.5 |
 | Azure Provider | >= 4.57.0, < 5.0.0 |
-| Docker Provider | 3.6.2 |
+
+## 🔌 Providers
+
+This module is provider-agnostic: it declares `azurerm` in `required_providers` but does **not** configure it internally. Configure the provider in your root module and pass it explicitly via the `providers` argument. This is what lets you use `count`, `for_each`, or `depends_on` on the module block, and lets a minimal/standalone config destroy the resources it created.
+
+The container image is built and pushed to its own Azure Container Registry entirely internally (the nested ACR submodule configures its own `docker` provider against the registry it creates), so no `docker` provider needs to be configured or passed in by the caller.
+
+```hcl
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+module "container_app" {
+  source    = "yaalalabs/ak-containerized/azurerm"
+  version   = "0.8.0"
+  providers = { azurerm = azurerm }
+
+  # ... other inputs, see below
+}
+```
 
 ## 🚀 Usage
 
@@ -29,7 +49,8 @@ Perfect for microservices, web applications, APIs requiring persistent connectio
 
 ```hcl
 module "container_app" {
-  source = "yaalalabs/ak-containerized/azurerm"
+  source    = "yaalalabs/ak-containerized/azurerm"
+  providers = { azurerm = azurerm }
 
   region               = "centralus"
   resource_group_name  = "myapp-prod-rg"

--- a/ak-deployment/ak-azure/containerized/main.tf
+++ b/ak-deployment/ak-azure/containerized/main.tf
@@ -5,22 +5,5 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 4.57.0, < 5.0.0"
     }
-    docker = {
-      source  = "kreuzwerker/docker"
-      version = "3.6.2"
-    }
-  }
-}
-
-provider "azurerm" {
-  features {}
-  resource_provider_registrations = "none"
-}
-
-provider "docker" {
-  registry_auth {
-    address  = try(module.docker_image.login_server, null)
-    username = try(module.docker_image.admin_username, null)
-    password = try(module.docker_image.admin_password, null)
   }
 }

--- a/ak-deployment/ak-azure/serverless/README.md
+++ b/ak-deployment/ak-azure/serverless/README.md
@@ -22,8 +22,26 @@ Perfect for microservices, API backends, event-driven architectures, and serverl
 |------|---------|
 | Terraform | >= 1.9.5 |
 | Azure Provider | >= 4.57.0, < 5.0.0 |
-| Docker Provider | 3.6.2 |
 | Null Provider | 3.2.4 |
+
+## 🔌 Providers
+
+This module is provider-agnostic: it declares `azurerm` in `required_providers` but does **not** configure it internally. Configure the provider in your root module and pass it explicitly via the `providers` argument. This is what lets you use `count`, `for_each`, or `depends_on` on the module block, and lets a minimal/standalone config destroy the resources it created.
+
+```hcl
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+module "python_api" {
+  source    = "yaalalabs/ak-serverless/azurerm"
+  version   = "0.8.0"
+  providers = { azurerm = azurerm }
+
+  # ... other inputs, see below
+}
+```
 
 ## 🚀 Usage
 
@@ -31,7 +49,8 @@ Perfect for microservices, API backends, event-driven architectures, and serverl
 
 ```hcl
 module "python_api" {
-  source = "yaalalabs/ak-serverless/azurerm"
+  source    = "yaalalabs/ak-serverless/azurerm"
+  providers = { azurerm = azurerm }
 
   region               = "centralus"
   resource_group_name  = "myapp-prod-rg"

--- a/ak-deployment/ak-azure/serverless/main.tf
+++ b/ak-deployment/ak-azure/serverless/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 4.57.0, < 5.0.0"
     }
-    docker = {
-      source  = "kreuzwerker/docker"
-      version = "3.6.2"
-    }
 
     null = {
       source  = "hashicorp/null"
@@ -16,9 +12,4 @@ terraform {
     }
 
   }
-}
-
-provider "azurerm" {
-  features {}
-  resource_provider_registrations = "none"
 }

--- a/ak-deployment/ak-gcp/containerized/README.md
+++ b/ak-deployment/ak-gcp/containerized/README.md
@@ -27,13 +27,49 @@ Perfect for microservices, web applications, APIs requiring persistent connectio
 | Google Beta Provider | >= 6.8.0 |
 | Docker Provider | 3.6.2 |
 
+## 🔌 Providers
+
+This module is provider-agnostic: it declares `google`, `google-beta`, and `docker` in `required_providers` but does **not** configure them internally. Configure all three providers in your root module and pass them explicitly via the `providers` argument. This is what lets you use `count`, `for_each`, or `depends_on` on the module block, and lets a minimal/standalone config destroy the resources it created.
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Docker authenticates against Artifact Registry to push the images this module builds
+data "google_client_config" "current" {}
+
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+
+module "container_app" {
+  source    = "yaalalabs/ak-containerized/google"
+  version   = "0.8.0"
+  providers = { google = google, google-beta = google-beta, docker = docker }
+
+  # ... other inputs, see below
+}
+```
+
 ## 🚀 Usage
 
 ### Basic Containerized API
 
 ```hcl
 module "container_app" {
-  source = "yaalalabs/ak-containerized/google"
+  source    = "yaalalabs/ak-containerized/google"
+  providers = { google = google, google-beta = google-beta, docker = docker }
 
   project_id           = "my-gcp-project"
   region               = "us-central1"

--- a/ak-deployment/ak-gcp/containerized/main.tf
+++ b/ak-deployment/ak-gcp/containerized/main.tf
@@ -1,13 +1,3 @@
-provider "google" {
-  project = var.project_id
-  region  = var.region
-}
-
-provider "google-beta" {
-  project = var.project_id
-  region  = var.region
-}
-
 terraform {
   required_providers {
     google = {
@@ -25,14 +15,3 @@ terraform {
   }
   required_version = ">= 1.9.5"
 }
-
-# Authenticate Docker to push images to Artifact Registry
-provider "docker" {
-  registry_auth {
-    address  = "${var.region}-docker.pkg.dev"
-    username = "oauth2accesstoken"
-    password = data.google_client_config.current.access_token
-  }
-}
-
-data "google_client_config" "current" {}

--- a/ak-deployment/ak-gcp/serverless/README.md
+++ b/ak-deployment/ak-gcp/serverless/README.md
@@ -25,13 +25,49 @@ Perfect for microservices, API backends, event-driven architectures, and serverl
 | Google Beta Provider | >= 6.8.0 |
 | Docker Provider | 3.6.2 |
 
+## 🔌 Providers
+
+This module is provider-agnostic: it declares `google`, `google-beta`, and `docker` in `required_providers` but does **not** configure them internally. Configure all three providers in your root module and pass them explicitly via the `providers` argument. This is what lets you use `count`, `for_each`, or `depends_on` on the module block, and lets a minimal/standalone config destroy the resources it created.
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Docker authenticates against Artifact Registry to push the images this module builds
+data "google_client_config" "current" {}
+
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+
+module "serverless_agent" {
+  source    = "yaalalabs/ak-serverless/google"
+  version   = "0.8.0"
+  providers = { google = google, google-beta = google-beta, docker = docker }
+
+  # ... other inputs, see below
+}
+```
+
 ## 🚀 Usage
 
 ### Basic Serverless Deployment
 
 ```hcl
 module "serverless_agent" {
-  source = "yaalalabs/ak-serverless/google"
+  source    = "yaalalabs/ak-serverless/google"
+  providers = { google = google, google-beta = google-beta, docker = docker }
 
   project_id           = "my-gcp-project"
   region               = "us-central1"

--- a/ak-deployment/ak-gcp/serverless/main.tf
+++ b/ak-deployment/ak-gcp/serverless/main.tf
@@ -1,13 +1,3 @@
-provider "google" {
-  project = var.project_id
-  region  = var.region
-}
-
-provider "google-beta" {
-  project = var.project_id
-  region  = var.region
-}
-
 terraform {
   required_providers {
     google = {
@@ -25,14 +15,3 @@ terraform {
   }
   required_version = ">= 1.9.5"
 }
-
-# Authenticate Docker to push images to Artifact Registry
-provider "docker" {
-  registry_auth {
-    address  = "${var.region}-docker.pkg.dev"
-    username = "oauth2accesstoken"
-    password = data.google_client_config.current.access_token
-  }
-}
-
-data "google_client_config" "current" {}

--- a/docs/docs/deployment/aws-containerized.md
+++ b/docs/docs/deployment/aws-containerized.md
@@ -65,6 +65,36 @@ if __name__ == "__main__":
 
 Refer to [example ECS implementation](https://github.com/yaalalabs/agent-kernel/tree/develop/examples/aws-containerized/crewai) which leverages Agent Kernel's [terraform module](https://registry.terraform.io/modules/yaalalabs/ak-containerized/aws) for ECS deployment.
 
+The module is provider-agnostic — it does not configure the `aws`/`docker` providers itself, so your root `main.tf` must configure them and pass them into the module explicitly:
+
+```hcl
+provider "aws" {
+  region = var.region
+}
+
+# Docker authenticates against ECR to push the images this module builds
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+module "containerized_agents" {
+  source    = "yaalalabs/ak-containerized/aws"
+  version   = "0.8.0"
+  providers = { aws = aws, docker = docker }
+
+  # ... other configuration
+}
+```
+
+See the [ak-aws/containerized module docs](https://github.com/yaalalabs/agent-kernel/tree/develop/ak-deployment/ak-aws/containerized#providers) for details.
+
 ## Scalable Queue Mode
 
 For high-throughput or long-running agents, use the two-container queue architecture.

--- a/docs/docs/deployment/aws-serverless.md
+++ b/docs/docs/deployment/aws-serverless.md
@@ -181,6 +181,36 @@ uv pip install --force-reinstall --no-deps agentkernel[api,aws] --target=auth_di
 
 Refer to [Terraform modules](https://registry.terraform.io/modules/yaalalabs/ak-serverless/aws) for configuration details.
 
+The module is provider-agnostic — it does not configure the `aws`/`docker` providers itself, so your root `main.tf` must configure them and pass them into the module explicitly:
+
+```hcl
+provider "aws" {
+  region = var.region
+}
+
+# Docker authenticates against ECR to push the images this module builds
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+module "serverless_agents" {
+  source    = "yaalalabs/ak-serverless/aws"
+  version   = "0.8.0"
+  providers = { aws = aws, docker = docker }
+
+  # ... other configuration
+}
+```
+
+See the [ak-aws/serverless module docs](https://github.com/yaalalabs/agent-kernel/tree/develop/ak-deployment/ak-aws/serverless#-providers) for details.
+
 ### 3. Deploy
 
 ```bash

--- a/docs/docs/deployment/azure-containerized.md
+++ b/docs/docs/deployment/azure-containerized.md
@@ -41,6 +41,25 @@ graph TB
 
 Refer to [example Azure Container Apps implementation](https://github.com/yaalalabs/agent-kernel/tree/develop/examples/azure-containerized/crewai) which leverages Agent Kernel's [terraform module](https://registry.terraform.io/modules/yaalalabs/ak-containerized/azurerm) for Container Apps deployment.
 
+The module is provider-agnostic — it does not configure the `azurerm` provider itself, so your root `main.tf` must configure it and pass it into the module explicitly:
+
+```hcl
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+module "container_app" {
+  source    = "yaalalabs/ak-containerized/azurerm"
+  version   = "0.8.0"
+  providers = { azurerm = azurerm }
+
+  # ... other configuration
+}
+```
+
+See the [ak-azure/containerized module docs](https://github.com/yaalalabs/agent-kernel/tree/develop/ak-deployment/ak-azure/containerized#-providers) for details.
+
 ## Advantages
 
 - **No cold starts** - containers always warm

--- a/docs/docs/deployment/azure-serverless.md
+++ b/docs/docs/deployment/azure-serverless.md
@@ -42,6 +42,25 @@ pip install agentkernel[azure,openai]
 
 Refer to [Terraform modules](https://registry.terraform.io/modules/yaalalabs/ak-serverless/azurerm) for configuration details.
 
+The module is provider-agnostic — it does not configure the `azurerm` provider itself, so your root `main.tf` must configure it and pass it into the module explicitly:
+
+```hcl
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+module "FlexFunction" {
+  source    = "yaalalabs/ak-serverless/azurerm"
+  version   = "0.8.0"
+  providers = { azurerm = azurerm }
+
+  # ... other configuration
+}
+```
+
+See the [ak-azure/serverless module docs](https://github.com/yaalalabs/agent-kernel/tree/develop/ak-deployment/ak-azure/serverless#-providers) for details.
+
 ### 3. Deploy
 
 ```bash

--- a/docs/docs/deployment/gcp-containerized.md
+++ b/docs/docs/deployment/gcp-containerized.md
@@ -71,12 +71,42 @@ dependencies = [
 
 ## Terraform Configuration
 
+### Providers
+
+The module is provider-agnostic — it does not configure the `google`/`google-beta`/`docker` providers itself, so your root `main.tf` must configure them and pass them into the module explicitly:
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Docker authenticates against Artifact Registry to push the images this module builds
+data "google_client_config" "current" {}
+
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+```
+
+Pass them into every `module "containerized_agent"` block below via `providers = { google = google, google-beta = google-beta, docker = docker }`. See the [ak-gcp/containerized module docs](https://github.com/yaalalabs/agent-kernel/tree/develop/ak-deployment/ak-gcp/containerized#-providers) for details.
+
 ### Basic Deployment (with Redis, always-on)
 
 ```hcl
 module "containerized_agent" {
-  source  = "yaalalabs/ak-containerized/google"
-  version = "0.2.14"
+  source    = "yaalalabs/ak-containerized/google"
+  version   = "0.8.0"
+  providers = { google = google, google-beta = google-beta, docker = docker }
 
   project_id           = var.project_id
   region               = var.region
@@ -106,8 +136,9 @@ module "containerized_agent" {
 
 ```hcl
 module "containerized_agent" {
-  source  = "yaalalabs/ak-containerized/google"
-  version = "0.2.14"
+  source    = "yaalalabs/ak-containerized/google"
+  version   = "0.8.0"
+  providers = { google = google, google-beta = google-beta, docker = docker }
 
   project_id           = var.project_id
   region               = var.region

--- a/docs/docs/deployment/gcp-serverless.md
+++ b/docs/docs/deployment/gcp-serverless.md
@@ -71,12 +71,42 @@ dependencies = [
 
 ## Terraform Configuration
 
+### Providers
+
+The module is provider-agnostic — it does not configure the `google`/`google-beta`/`docker` providers itself, so your root `main.tf` must configure them and pass them into the module explicitly:
+
+```hcl
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Docker authenticates against Artifact Registry to push the images this module builds
+data "google_client_config" "current" {}
+
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+```
+
+Pass them into every `module "serverless_agent"` block below via `providers = { google = google, google-beta = google-beta, docker = docker }`. See the [ak-gcp/serverless module docs](https://github.com/yaalalabs/agent-kernel/tree/develop/ak-deployment/ak-gcp/serverless#-providers) for details.
+
 ### Basic Deployment (with Redis)
 
 ```hcl
 module "serverless_agent" {
-  source  = "yaalalabs/ak-serverless/google"
-  version = "0.2.14"
+  source    = "yaalalabs/ak-serverless/google"
+  version   = "0.8.0"
+  providers = { google = google, google-beta = google-beta, docker = docker }
 
   project_id           = var.project_id
   region               = var.region
@@ -104,8 +134,9 @@ module "serverless_agent" {
 
 ```hcl
 module "serverless_agent" {
-  source  = "yaalalabs/ak-serverless/google"
-  version = "0.2.14"
+  source    = "yaalalabs/ak-serverless/google"
+  version   = "0.8.0"
+  providers = { google = google, google-beta = google-beta, docker = docker }
 
   project_id           = var.project_id
   region               = var.region
@@ -132,8 +163,9 @@ When `create_firestore_db = true`, the module automatically injects:
 
 ```hcl
 module "serverless_agent" {
-  source  = "yaalalabs/ak-serverless/google"
-  version = "0.2.14"
+  source    = "yaalalabs/ak-serverless/google"
+  version   = "0.8.0"
+  providers = { google = google, google-beta = google-beta, docker = docker }
 
   project_id           = var.project_id
   region               = var.region

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -506,6 +506,16 @@ Create a deployment folder and add `deploy/main.tf`:
 ```hcl
 terraform {
     required_version = ">= 1.9.5"
+    required_providers {
+        aws = {
+            source  = "hashicorp/aws"
+            version = ">= 6.11.0"
+        }
+        docker = {
+            source  = "kreuzwerker/docker"
+            version = "3.6.2"
+        }
+    }
 }
 
 variable "region" {
@@ -518,9 +528,26 @@ variable "openai_api_key" {
     sensitive = true
 }
 
+provider "aws" {
+    region = var.region
+}
+
+# Docker authenticates against ECR to push the image this module builds
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+    registry_auth {
+        address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+        username = data.aws_ecr_authorization_token.token.user_name
+        password = data.aws_ecr_authorization_token.token.password
+    }
+}
+
 module "serverless_agents" {
-    source  = "yaalalabs/ak-serverless/aws"
-    version = "0.5.1"
+    source    = "yaalalabs/ak-serverless/aws"
+    version   = "0.8.0"
+    providers = { aws = aws, docker = docker }
 
     product_alias        = "ak"
     env_alias            = "dev"

--- a/examples/api/multimodal/dynamodb/deploy/main.tf
+++ b/examples/api/multimodal/dynamodb/deploy/main.tf
@@ -4,24 +4,25 @@ module "serverless_agents" {
   source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
-  product_alias                = var.product_alias
-  env_alias                    = var.env_alias
-  module_name                  = var.module_name
+  product_alias                           = var.product_alias
+  env_alias                               = var.env_alias
+  module_name                             = var.module_name
   create_dynamodb_multimodal_memory_table = true
-  product_display_name         = "Agent Kernel OpenAI Multimodal with DynamoDB"
-  region                       = var.region
+  product_display_name                    = "Agent Kernel OpenAI Multimodal with DynamoDB"
+  region                                  = var.region
 
   # Request handler configuration
   request_handler = {
-    function_description         = "Agent Kernel OpenAI Multimodal with DynamoDB"
-    function_name                = "mm-ddb"
-    handler_path                 = "lambda.handler" # Set dummy valid file to skip validaton inside zip
-    module_name                  = var.module_name
-    package_path                 = "../dist"
-    package_type                 = "Image"
-    memory_size                  = 2048
-    timeout                      = 60
+    function_description = "Agent Kernel OpenAI Multimodal with DynamoDB"
+    function_name        = "mm-ddb"
+    handler_path         = "lambda.handler" # Set dummy valid file to skip validaton inside zip
+    module_name          = var.module_name
+    package_path         = "../dist"
+    package_type         = "Image"
+    memory_size          = 2048
+    timeout              = 60
     environment_variables = {
       "OPENAI_API_KEY" = var.openai_api_key
     }

--- a/examples/api/multimodal/dynamodb/deploy/providers.tf
+++ b/examples/api/multimodal/dynamodb/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/api/multimodal/redis/deploy/main.tf
+++ b/examples/api/multimodal/redis/deploy/main.tf
@@ -3,6 +3,7 @@ module "serverless_agents" {
   source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/api/multimodal/redis/deploy/providers.tf
+++ b/examples/api/multimodal/redis/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-containerized/adk/deploy/main.tf
+++ b/examples/aws-containerized/adk/deploy/main.tf
@@ -1,8 +1,9 @@
 # Containered module configuration for deploying Google ADK Agent in ECS
 module "containered_agents" {
-  source = "yaalalabs/ak-containerized/aws"
+  source  = "yaalalabs/ak-containerized/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic ECS configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/aws-containerized/adk/deploy/providers.tf
+++ b/examples/aws-containerized/adk/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-containerized/crewai-auth/deploy/main.tf
+++ b/examples/aws-containerized/crewai-auth/deploy/main.tf
@@ -4,9 +4,10 @@
 # /api/v1/app - Custom endpoint created via a direct route addition
 # /api/v1/app_info - Custom endpoint created by a custom handler
 module "containered_agents" {
-  source = "yaalalabs/ak-containerized/aws"
+  source  = "yaalalabs/ak-containerized/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic ECS configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/aws-containerized/crewai-auth/deploy/providers.tf
+++ b/examples/aws-containerized/crewai-auth/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-containerized/crewai/deploy/main.tf
+++ b/examples/aws-containerized/crewai/deploy/main.tf
@@ -4,9 +4,10 @@
 # /api/v1/app - Custom endpoint created via a direct route addition
 # /api/v1/app_info - Custom endpoint created by a custom handler
 module "containered_agents" {
-  source = "yaalalabs/ak-containerized/aws"
+  source  = "yaalalabs/ak-containerized/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic ECS configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/aws-containerized/crewai/deploy/providers.tf
+++ b/examples/aws-containerized/crewai/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-containerized/mcp/multi/README.md
+++ b/examples/aws-containerized/mcp/multi/README.md
@@ -34,8 +34,9 @@ This automatically creates an MCP endpoint at:
 ```hcl
 # Containerized module configuration for deploying MCP in ECS
 module "containered_agents" {
-  source  = "yaalalabs/ak-containerized/aws"
-  version = "0.6.0"
+  source    = "yaalalabs/ak-containerized/aws"
+  version   = "0.8.0"
+  providers = { aws = aws, docker = docker }
 
   # Basic ECS configuration
   product_alias        = var.product_alias

--- a/examples/aws-containerized/mcp/multi/deploy/main.tf
+++ b/examples/aws-containerized/mcp/multi/deploy/main.tf
@@ -1,8 +1,9 @@
 # Containered module configuration for deploying MCP in ECS
 module "containered_agents" {
-  source = "yaalalabs/ak-containerized/aws"
+  source  = "yaalalabs/ak-containerized/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic ECS configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/aws-containerized/mcp/multi/deploy/providers.tf
+++ b/examples/aws-containerized/mcp/multi/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-containerized/openai-dynamodb-scalable/deploy/main.tf
+++ b/examples/aws-containerized/openai-dynamodb-scalable/deploy/main.tf
@@ -6,6 +6,7 @@ module "containerized_agents" {
   source  = "yaalalabs/ak-containerized/aws"
   version = "0.8.0"
 
+  providers            = { aws = aws, docker = docker }
   product_alias        = var.product_alias
   env_alias            = var.env_alias
   module_name          = var.module_name

--- a/examples/aws-containerized/openai-dynamodb-scalable/deploy/providers.tf
+++ b/examples/aws-containerized/openai-dynamodb-scalable/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-containerized/openai-dynamodb/deploy/main.tf
+++ b/examples/aws-containerized/openai-dynamodb/deploy/main.tf
@@ -1,8 +1,9 @@
 # Containered module configuration for deploying OpenAI Agent in ECS
 module "containered_agents" {
-  source = "yaalalabs/ak-containerized/aws"
+  source  = "yaalalabs/ak-containerized/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic ECS configuration
   product_alias                = var.product_alias
   env_alias                    = var.env_alias

--- a/examples/aws-containerized/openai-dynamodb/deploy/providers.tf
+++ b/examples/aws-containerized/openai-dynamodb/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/adk/deploy/main.tf
+++ b/examples/aws-serverless/adk/deploy/main.tf
@@ -1,8 +1,9 @@
 # Lambda module configuration for deploying Google Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias
@@ -14,16 +15,16 @@ module "serverless_agents" {
 
   # Request handler configuration
   request_handler = {
-    function_name         = "adk-agents"
-    function_description   = "Agent Kernel ADK Sample Lambda"
-    handler_path          = "lambda.handler"
-    module_name           = var.module_name
-    package_path          = "../dist"
-    package_type          = "Image"
-    memory_size           = 1024
-    timeout               = 60
+    function_name        = "adk-agents"
+    function_description = "Agent Kernel ADK Sample Lambda"
+    handler_path         = "lambda.handler"
+    module_name          = var.module_name
+    package_path         = "../dist"
+    package_type         = "Image"
+    memory_size          = 1024
+    timeout              = 60
     environment_variables = {
-      OPENAI_API_KEY     = var.openai_api_key,
+      OPENAI_API_KEY = var.openai_api_key,
     }
   }
 }

--- a/examples/aws-serverless/adk/deploy/providers.tf
+++ b/examples/aws-serverless/adk/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/crewai/deploy/main.tf
+++ b/examples/aws-serverless/crewai/deploy/main.tf
@@ -1,8 +1,9 @@
 # Lambda module configuration for deploying OpenAI Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias
@@ -14,14 +15,14 @@ module "serverless_agents" {
 
   # Request handler configuration
   request_handler = {
-    function_name         = "crewai-agents"
-    function_description   = "Agent Kernel CrewAI Sample Lambda"
-    handler_path          = "lambda.handler"
-    module_name           = var.module_name
-    package_path          = "../dist"
-    package_type          = "Image"
-    memory_size           = 1024
-    timeout               = 60
+    function_name        = "crewai-agents"
+    function_description = "Agent Kernel CrewAI Sample Lambda"
+    handler_path         = "lambda.handler"
+    module_name          = var.module_name
+    package_path         = "../dist"
+    package_type         = "Image"
+    memory_size          = 1024
+    timeout              = 60
     environment_variables = {
       OPENAI_API_KEY     = var.openai_api_key,
       CREWAI_STORAGE_DIR = "/tmp/crewai",

--- a/examples/aws-serverless/crewai/deploy/providers.tf
+++ b/examples/aws-serverless/crewai/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/langgraph/deploy/main.tf
+++ b/examples/aws-serverless/langgraph/deploy/main.tf
@@ -1,8 +1,9 @@
 # Lambda module configuration for deploying OpenAI Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias
@@ -14,13 +15,13 @@ module "serverless_agents" {
 
   # Request handler configuration
   request_handler = {
-    function_name         = "langgraph-agents"
-    function_description   = "Agent Kernel LangGraph Sample Lambda"
-    handler_path          = "lambda.handler"
-    module_name           = var.module_name
-    package_path          = "../dist"
-    package_type          = "Image"
-    memory_size           = 1024
+    function_name        = "langgraph-agents"
+    function_description = "Agent Kernel LangGraph Sample Lambda"
+    handler_path         = "lambda.handler"
+    module_name          = var.module_name
+    package_path         = "../dist"
+    package_type         = "Image"
+    memory_size          = 1024
     environment_variables = {
       "OPENAI_API_KEY" = var.openai_api_key
     }

--- a/examples/aws-serverless/langgraph/deploy/providers.tf
+++ b/examples/aws-serverless/langgraph/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/openai-auth/deploy/main.tf
+++ b/examples/aws-serverless/openai-auth/deploy/main.tf
@@ -1,8 +1,9 @@
 # Lambda module configuration for deploying OpenAI Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias
@@ -17,13 +18,13 @@ module "serverless_agents" {
 
   # Request handler configuration
   request_handler = {
-    function_name         = "openai-auth-agents"
-    function_description   = "Agent Kernel OpenAI Auth Sample Lambda"
-    handler_path          = "lambda.handler"
-    module_name           = var.module_name
-    package_path          = "../dist"
-    package_type          = "Image"
-    memory_size           = 256
+    function_name        = "openai-auth-agents"
+    function_description = "Agent Kernel OpenAI Auth Sample Lambda"
+    handler_path         = "lambda.handler"
+    module_name          = var.module_name
+    package_path         = "../dist"
+    package_type         = "Image"
+    memory_size          = 256
     environment_variables = {
       "OPENAI_API_KEY" = var.openai_api_key
     }
@@ -37,15 +38,15 @@ module "serverless_agents" {
   # Defining custom API endpoints
   gateway_endpoints = [
     {
-      path           = "app",
-      method         = "GET",
+      path   = "app",
+      method = "GET",
     },
     {
-      path           = "app_info",
-      method         = "POST",
+      path   = "app_info",
+      method = "POST",
     }
   ]
-  
+
   # Defining the API Gateway Authorizer
   authorizer = {
     description           = "API Gateway Lambda Authorizer"

--- a/examples/aws-serverless/openai-auth/deploy/providers.tf
+++ b/examples/aws-serverless/openai-auth/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/openai/deploy/main.tf
+++ b/examples/aws-serverless/openai/deploy/main.tf
@@ -1,8 +1,9 @@
 # Lambda module configuration for deploying OpenAI Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias
@@ -13,13 +14,13 @@ module "serverless_agents" {
 
   # Request handler configuration
   request_handler = {
-    function_name         = "openai-agents"
-    function_description   = "Agent Kernel OpenAI Sample Lambda"
-    handler_path          = "lambda.handler"
-    module_name           = var.module_name
-    package_path          = "../dist"
-    package_type          = "Image"
-    memory_size           = 1024
+    function_name        = "openai-agents"
+    function_description = "Agent Kernel OpenAI Sample Lambda"
+    handler_path         = "lambda.handler"
+    module_name          = var.module_name
+    package_path         = "../dist"
+    package_type         = "Image"
+    memory_size          = 1024
     environment_variables = {
       "OPENAI_API_KEY" = var.openai_api_key
     }
@@ -33,12 +34,12 @@ module "serverless_agents" {
   # Defining custom API endpoints
   gateway_endpoints = [
     {
-      path           = "app",
-      method         = "GET",
+      path   = "app",
+      method = "GET",
     },
     {
-      path           = "app_info",
-      method         = "POST",
+      path   = "app_info",
+      method = "POST",
     }
   ]
 }

--- a/examples/aws-serverless/openai/deploy/providers.tf
+++ b/examples/aws-serverless/openai/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/scalable-openai/deploy/main.tf
+++ b/examples/aws-serverless/scalable-openai/deploy/main.tf
@@ -1,8 +1,9 @@
 # Scalable OpenAI Agent deployment using the updated serverless module
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/aws-serverless/scalable-openai/deploy/providers.tf
+++ b/examples/aws-serverless/scalable-openai/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/streaming-openai/deploy/main.tf
+++ b/examples/aws-serverless/streaming-openai/deploy/main.tf
@@ -2,6 +2,7 @@ module "serverless_agents" {
   source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/aws-serverless/streaming-openai/deploy/providers.tf
+++ b/examples/aws-serverless/streaming-openai/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/aws-serverless/websocket-openai/deploy/main.tf
+++ b/examples/aws-serverless/websocket-openai/deploy/main.tf
@@ -2,6 +2,7 @@ module "serverless_agents" {
   source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias
@@ -11,7 +12,7 @@ module "serverless_agents" {
   is_production        = var.is_production
 
   # Execution mode - using for WebSocket processing
-  queue_mode     = true # recommended for production
+  queue_mode     = true    # recommended for production
   execution_mode = "async" # rest_sync, rest_async, or async
 
   # Memory DB Config
@@ -27,14 +28,14 @@ module "serverless_agents" {
 
   # Request handler configuration
   request_handler = {
-    module_name           = "rqst-hdlr"
-    function_name         = "rqh-func"
-    function_description  = "Agent Kernel OpenAI WebSocket Sample Lambda"
-    handler_path          = "lambda_request_handler.handler"
-    package_type          = "LocalZip"
-    package_path          = "../dist_request_handler.zip"
-    memory_size           = 256
-    timeout               = 45
+    module_name          = "rqst-hdlr"
+    function_name        = "rqh-func"
+    function_description = "Agent Kernel OpenAI WebSocket Sample Lambda"
+    handler_path         = "lambda_request_handler.handler"
+    package_type         = "LocalZip"
+    package_path         = "../dist_request_handler.zip"
+    memory_size          = 256
+    timeout              = 45
     environment_variables = {
       "OPENAI_API_KEY" = var.openai_api_key
     }
@@ -42,14 +43,14 @@ module "serverless_agents" {
 
   # Agent runner configuration
   agent_runner = {
-    module_name           = "agent-runner"
-    function_name         = "ar-func"
-    function_description  = "Agent runner for processing OpenAI requests"
-    timeout               = 45
-    memory_size           = 512
-    handler_path          = "lambda_agent_runner.handler"
-    package_path          = "../dist_agent_runner"
-    package_type          = "Image"
+    module_name          = "agent-runner"
+    function_name        = "ar-func"
+    function_description = "Agent runner for processing OpenAI requests"
+    timeout              = 45
+    memory_size          = 512
+    handler_path         = "lambda_agent_runner.handler"
+    package_path         = "../dist_agent_runner"
+    package_type         = "Image"
     environment_variables = {
       "OPENAI_API_KEY" = var.openai_api_key
     }
@@ -57,41 +58,41 @@ module "serverless_agents" {
 
   # Response handler configuration
   response_handler = {
-    function_name         = "res-func"
-    module_name           = "response-handler"
-    function_description  = "Response handler for processing completed requests"
-    timeout               = 45
-    memory_size           = 256
-    handler_path          = "lambda_response_handler.handler"
-    package_type          = "LocalZip"
-    package_path          = "../dist_response_handler.zip"
+    function_name        = "res-func"
+    module_name          = "response-handler"
+    function_description = "Response handler for processing completed requests"
+    timeout              = 45
+    memory_size          = 256
+    handler_path         = "lambda_response_handler.handler"
+    package_type         = "LocalZip"
+    package_path         = "../dist_response_handler.zip"
   }
 
   # WebSocket connection handler configuration
   ws_connection_handler = {
-    function_name         = "ws-con-func"
-    module_name           = "ws-con-hdlr"
-    function_description  = "WebSocket connection handler for $connect and $disconnect routes"
-    timeout               = 45
-    memory_size           = 256
-    handler_path          = "lambda_ws_connection_handler.handler"
-    package_path          = "../dist_ws_connection_handler.zip"
+    function_name        = "ws-con-func"
+    module_name          = "ws-con-hdlr"
+    function_description = "WebSocket connection handler for $connect and $disconnect routes"
+    timeout              = 45
+    memory_size          = 256
+    handler_path         = "lambda_ws_connection_handler.handler"
+    package_path         = "../dist_ws_connection_handler.zip"
   }
 
   # Queue configuration for scalable processing
   queue_config = {
     # Input queue settings
-    input_queue_visibility_timeout = 60 # make sure to set it higher than the lambda timeout to avoid multiple processing of the same message
-    input_queue_max_receive_count   = 3 
-    input_queue_create_dlq          = false
+    input_queue_visibility_timeout        = 60 # make sure to set it higher than the lambda timeout to avoid multiple processing of the same message
+    input_queue_max_receive_count         = 3
+    input_queue_create_dlq                = false
     input_queue_message_retention_seconds = 300
-    
+
     # Output queue settings  
-    output_queue_visibility_timeout = 60 # make sure to set it higher than the lambda timeout to avoid multiple processing of the same message
-    output_queue_max_receive_count   = 3
-    output_queue_create_dlq          = false 
+    output_queue_visibility_timeout        = 60 # make sure to set it higher than the lambda timeout to avoid multiple processing of the same message
+    output_queue_max_receive_count         = 3
+    output_queue_create_dlq                = false
     output_queue_message_retention_seconds = 300
-    
+
     # Processing settings
     batch_size                         = 10
     maximum_batching_window_in_seconds = 0

--- a/examples/aws-serverless/websocket-openai/deploy/providers.tf
+++ b/examples/aws-serverless/websocket-openai/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/azure-containerized/openai-cosmos/deploy/main.tf
+++ b/examples/azure-containerized/openai-cosmos/deploy/main.tf
@@ -1,6 +1,7 @@
 module "containerd_agent" {
   source              = "yaalalabs/ak-containerized/azurerm"
   version             = "0.8.0"
+  providers           = { azurerm = azurerm }
   product_alias       = var.product_alias
   env_alias           = var.env_alias
   module_name         = var.module_name

--- a/examples/azure-containerized/openai-cosmos/deploy/providers.tf
+++ b/examples/azure-containerized/openai-cosmos/deploy/providers.tf
@@ -1,0 +1,14 @@
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.57.0, < 5.0.0"
+    }
+  }
+}

--- a/examples/azure-serverless/openai/deploy/main.tf
+++ b/examples/azure-serverless/openai/deploy/main.tf
@@ -1,6 +1,7 @@
 module "FlexFunction" {
   source                  = "yaalalabs/ak-serverless/azurerm"
   version                 = "0.8.0"
+  providers               = { azurerm = azurerm }
   product_alias           = var.product_alias
   env_alias               = var.env_alias
   function_description    = "Agent Kernel OpenAI Sample Azure Function"

--- a/examples/azure-serverless/openai/deploy/providers.tf
+++ b/examples/azure-serverless/openai/deploy/providers.tf
@@ -1,0 +1,14 @@
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.57.0, < 5.0.0"
+    }
+  }
+}

--- a/examples/gcp-containerized/openai-auth/deploy/main.tf
+++ b/examples/gcp-containerized/openai-auth/deploy/main.tf
@@ -2,6 +2,7 @@ module "containerized_agents" {
   source  = "yaalalabs/ak-containerized/google"
   version = "0.8.0"
 
+  providers = { google = google, google-beta = google-beta, docker = docker }
   # Basic Cloud Run configuration
   project_id           = var.project_id
   product_alias        = var.product_alias
@@ -43,8 +44,8 @@ module "containerized_agents" {
   # API Gateway (ESPv2) validates Google Identity Tokens before forwarding to Cloud Run.
   # Clients must pass: Authorization: Bearer $(gcloud auth print-identity-token)
   authorizer = {
-    issuer    = "https://accounts.google.com"
-    jwks_uri  = "https://www.googleapis.com/oauth2/v3/certs"
+    issuer   = "https://accounts.google.com"
+    jwks_uri = "https://www.googleapis.com/oauth2/v3/certs"
     # User identity tokens from `gcloud auth print-identity-token` use the gcloud SDK client ID as audience.
     # For service-to-service auth (service account tokens), use the Cloud Run service URL instead.
     audiences = ["32555940559.apps.googleusercontent.com"]

--- a/examples/gcp-containerized/openai-auth/deploy/providers.tf
+++ b/examples/gcp-containerized/openai-auth/deploy/providers.tf
@@ -1,0 +1,38 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "current" {}
+
+# Authenticate Docker to push images to Artifact Registry
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.8.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.8.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/gcp-containerized/openai/deploy/main.tf
+++ b/examples/gcp-containerized/openai/deploy/main.tf
@@ -7,6 +7,7 @@ module "containerized_agents" {
   source  = "yaalalabs/ak-containerized/google"
   version = "0.8.0"
 
+  providers = { google = google, google-beta = google-beta, docker = docker }
   # Basic Cloud Run configuration
   project_id           = var.project_id
   product_alias        = var.product_alias

--- a/examples/gcp-containerized/openai/deploy/providers.tf
+++ b/examples/gcp-containerized/openai/deploy/providers.tf
@@ -1,0 +1,38 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "current" {}
+
+# Authenticate Docker to push images to Artifact Registry
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.8.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.8.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/gcp-serverless/openai-auth/deploy/main.tf
+++ b/examples/gcp-serverless/openai-auth/deploy/main.tf
@@ -2,6 +2,7 @@ module "serverless_agents" {
   source  = "yaalalabs/ak-serverless/google"
   version = "0.8.0"
 
+  providers = { google = google, google-beta = google-beta, docker = docker }
   # Basic Cloud Run configuration
   project_id           = var.project_id
   product_alias        = var.product_alias
@@ -43,8 +44,8 @@ module "serverless_agents" {
   # API Gateway (ESPv2) validates Google Identity Tokens before forwarding to Cloud Run.
   # Clients must pass: Authorization: Bearer $(gcloud auth print-identity-token --audiences=<service_url>)
   authorizer = {
-    issuer    = "https://accounts.google.com"
-    jwks_uri  = "https://www.googleapis.com/oauth2/v3/certs"
+    issuer   = "https://accounts.google.com"
+    jwks_uri = "https://www.googleapis.com/oauth2/v3/certs"
     # User identity tokens from `gcloud auth print-identity-token` use the gcloud SDK client ID as audience.
     # For service-to-service auth (service account tokens), use the Cloud Run service URL instead.
     audiences = ["32555940559.apps.googleusercontent.com"]

--- a/examples/gcp-serverless/openai-auth/deploy/providers.tf
+++ b/examples/gcp-serverless/openai-auth/deploy/providers.tf
@@ -1,0 +1,38 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "current" {}
+
+# Authenticate Docker to push images to Artifact Registry
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.8.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.8.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/gcp-serverless/openai-firestore/deploy/main.tf
+++ b/examples/gcp-serverless/openai-firestore/deploy/main.tf
@@ -2,6 +2,7 @@ module "serverless_agents" {
   source  = "yaalalabs/ak-serverless/google"
   version = "0.8.0"
 
+  providers = { google = google, google-beta = google-beta, docker = docker }
   # Basic Cloud Run configuration
   project_id           = var.project_id
   product_alias        = var.product_alias

--- a/examples/gcp-serverless/openai-firestore/deploy/providers.tf
+++ b/examples/gcp-serverless/openai-firestore/deploy/providers.tf
@@ -1,0 +1,38 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "current" {}
+
+# Authenticate Docker to push images to Artifact Registry
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.8.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.8.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/gcp-serverless/openai/deploy/main.tf
+++ b/examples/gcp-serverless/openai/deploy/main.tf
@@ -10,6 +10,7 @@ module "serverless_agents" {
   source  = "yaalalabs/ak-serverless/google"
   version = "0.8.0"
 
+  providers = { google = google, google-beta = google-beta, docker = docker }
   # Basic Cloud Run configuration
   project_id           = var.project_id
   product_alias        = var.product_alias

--- a/examples/gcp-serverless/openai/deploy/providers.tf
+++ b/examples/gcp-serverless/openai/deploy/providers.tf
@@ -1,0 +1,38 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_client_config" "current" {}
+
+# Authenticate Docker to push images to Artifact Registry
+provider "docker" {
+  registry_auth {
+    address  = "${var.region}-docker.pkg.dev"
+    username = "oauth2accesstoken"
+    password = data.google_client_config.current.access_token
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.8.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.8.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/memory/cosmos/deploy/main.tf
+++ b/examples/memory/cosmos/deploy/main.tf
@@ -1,6 +1,7 @@
 module "FlexFunction" {
   source                  = "yaalalabs/ak-serverless/azurerm"
   version                 = "0.8.0"
+  providers               = { azurerm = azurerm }
   product_alias           = var.product_alias
   env_alias               = var.env_alias
   function_description    = "Agent Kernel OpenAI Sample Azure Function"

--- a/examples/memory/cosmos/deploy/providers.tf
+++ b/examples/memory/cosmos/deploy/providers.tf
@@ -1,0 +1,14 @@
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.57.0, < 5.0.0"
+    }
+  }
+}

--- a/examples/memory/dynamodb/deploy/main.tf
+++ b/examples/memory/dynamodb/deploy/main.tf
@@ -1,8 +1,9 @@
 # Lambda module configuration for deploying OpenAI Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias                = var.product_alias
   env_alias                    = var.env_alias
@@ -15,13 +16,13 @@ module "serverless_agents" {
 
   # Request handler configuration
   request_handler = {
-    function_description         = "Agent Kernel OpenAI with DynamoDB"
-    function_name                = "oai-ddb"
-    handler_path                 = "lambda.handler"
-    module_name                  = var.module_name
-    package_path                 = "../dist"
-    package_type                 = "Image"
-    memory_size                  = 512
+    function_description = "Agent Kernel OpenAI with DynamoDB"
+    function_name        = "oai-ddb"
+    handler_path         = "lambda.handler"
+    module_name          = var.module_name
+    package_path         = "../dist"
+    package_type         = "Image"
+    memory_size          = 512
     environment_variables = {
       "OPENAI_API_KEY" = var.openai_api_key
     }

--- a/examples/memory/dynamodb/deploy/providers.tf
+++ b/examples/memory/dynamodb/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/memory/redis/deploy/main.tf
+++ b/examples/memory/redis/deploy/main.tf
@@ -1,8 +1,9 @@
 # Lambda module configuration for deploying OpenAI Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
   product_alias        = var.product_alias
   env_alias            = var.env_alias

--- a/examples/memory/redis/deploy/providers.tf
+++ b/examples/memory/redis/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}

--- a/examples/memory/valkey/deploy/main.tf
+++ b/examples/memory/valkey/deploy/main.tf
@@ -1,17 +1,18 @@
 # Lambda module configuration for deploying OpenAI Agent Lambda function
 module "serverless_agents" {
-  source = "yaalalabs/ak-serverless/aws"
+  source  = "yaalalabs/ak-serverless/aws"
   version = "0.8.0"
 
+  providers = { aws = aws, docker = docker }
   # Basic lambda configuration
-  product_alias        = var.product_alias
-  env_alias            = var.env_alias
-  module_name          = var.module_name
-  product_display_name = "Agent Kernel OpenAI with Valkey"
+  product_alias         = var.product_alias
+  env_alias             = var.env_alias
+  module_name           = var.module_name
+  product_display_name  = "Agent Kernel OpenAI with Valkey"
   create_valkey_cluster = true # Creates an ElastiCache for Valkey cluster and injects AK_SESSION__VALKEY__URL. Set to false to reuse an existing Valkey host configured in config.yaml instead.
-  vpc_id               = var.vpc_id
-  private_subnet_ids   = var.private_subnet_ids
-  region               = var.region
+  vpc_id                = var.vpc_id
+  private_subnet_ids    = var.private_subnet_ids
+  region                = var.region
 
   # Request handler configuration
   request_handler = {

--- a/examples/memory/valkey/deploy/providers.tf
+++ b/examples/memory/valkey/deploy/providers.tf
@@ -1,0 +1,28 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_ecr_authorization_token" "token" {}
+
+provider "docker" {
+  registry_auth {
+    address  = format("%v.dkr.ecr.%v.amazonaws.com", data.aws_caller_identity.current.account_id, var.region)
+    username = data.aws_ecr_authorization_token.token.user_name
+    password = data.aws_ecr_authorization_token.token.password
+  }
+}
+
+terraform {
+  required_version = ">= 1.9.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.11.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+  }
+}


### PR DESCRIPTION
## Description

The AWS, Azure, and GCP `serverless` and `containerized` Terraform modules (plus `ak-azure/common`) each declared their own internal `provider "aws"` / `provider "azurerm"` / `provider "google"` / `provider "google-beta"` / `provider "docker"` blocks. Terraform forbids `count`, `for_each`, and `depends_on` on any module block that contains its own provider configuration, and it also binds the resources it creates to that module's own provider config — so a minimal/standalone config can't destroy them (`Error: Provider configuration not present`).

This PR makes all six module variants provider-agnostic: they now only declare what they need in `required_providers`, and the caller configures and passes providers in explicitly via `providers = {...}`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

This is a **breaking change for consumers of the published registry modules**: on the next release, callers must add a `providers = {...}` argument (and configure the underlying providers themselves) to their module blocks, or `terraform plan` will fail with a missing-provider-configuration error.

## Related Issues

Fixes #571

## Changes Made

- Removed the internal `provider` blocks from all 6 module variants: `ak-aws/serverless`, `ak-aws/containerized`, `ak-azure/serverless`, `ak-azure/containerized`, `ak-gcp/serverless`, `ak-gcp/containerized`, and from `ak-azure/common` (independently published, same anti-pattern).
- Removed now-unused registry-auth data sources that only existed to feed those internal provider blocks (kept `data.aws_caller_identity` in `ak-aws/containerized` since it's also used by `queue_mode.tf`).
- Dropped the dead `docker` provider requirement from `ak-azure/serverless` and `ak-azure/containerized` — neither module uses a `docker` resource at that level; the container image build/push is fully self-contained inside the nested ACR submodule, which configures its own `docker` provider against the ACR it creates. (Left that submodule as-is — its provider config is resource-dependent, a different problem than what this issue covers.)
- Updated all 27 example `deploy/main.tf` configs to configure the required providers and pass them explicitly (`providers = { aws = aws, docker = docker }` / `{ azurerm = azurerm }` / `{ google = google, google-beta = google-beta, docker = docker }`), each via a new `providers.tf` in the same directory.
- Added a "Providers" section with a copy-paste snippet (provider config + registry-auth data source) to all 6 module READMEs.
- Updated the Docusaurus deployment guides (`docs/docs/quick-start.md` and the 6 `docs/docs/deployment/*.md` pages) so following them still produces a working deployment.

## Testing

- [x] Manual testing completed
- [ ] Unit tests pass locally (no ak-py code changed)
- [ ] Integration tests pass locally (n/a)
- [ ] New tests added for changes (n/a — Terraform modules, no test suite)

Verified with real `terraform init`/`validate` runs (see below), since the registry still serves the old, unfixed module version until this is released — the vendored source was tested directly by pointing example configs at the local module path:

- Reproduced the original bug against the pre-fix module (`Error: Module is incompatible with count, for_each, and depends_on`), then confirmed it's gone after the fix.
- `terraform validate` passes cleanly on all 6 fixed modules and on `ak-azure/common` (only pre-existing, unrelated deprecation warnings from a vendored third-party submodule).
- `terraform init` + `validate` passes on one representative example per cloud/variant (`aws-serverless`, `aws-containerized`, `azure-serverless`, `azure-containerized`, `gcp-serverless`, `gcp-containerized`) against the local (fixed) module source with the new `providers = {...}` wiring.
- Confirmed `count = 1` is now accepted on the module block (previously a hard error).

## Checklist

- [x] My code follows the project's style guidelines (`terraform fmt`)
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes (no ak-py tests affected)
- [ ] Any dependent changes have been merged and published — **this PR alone is not enough**: the fix only takes effect for real consumers once the modules are re-released to the Terraform registry (`ak-serverless`/`ak-containerized` × `aws`/`azurerm`/`google`, plus `ak-common/azurerm`), per the existing release flow.

## Additional Notes

- Known pre-existing issue, left untouched: `docs/docs/deployment/azure-containerized.md` links to `examples/azure-containerized/crewai`, which doesn't exist (only `openai-cosmos` does). Unrelated to this fix.
- Not touched by design: `ak-azure/common/modules/acr`'s internal `docker` provider block. Its config reads attributes off the ACR resource it creates in the same module, so it can't simply be hoisted to the caller the way the others were — that would need a separate design (e.g. a two-phase apply or moving the build/push to a null_resource-driven Docker CLI step).
