### PR TITLE
feat: nats jetstream queue transport with local example (#495)

### DIFF
--- a/.github/test-config.yaml
+++ b/.github/test-config.yaml
@@ -110,3 +110,11 @@ e2e:
     # Containerized examples
     - type: containerized
       path: examples/containerized/openai
+
+    # Transport examples: each starts its broker with docker compose and skips itself when
+    # Docker is unavailable. They resolve the kafka/nats extras from the branch wheel that
+    # build-ak-py caches into ak-py/dist, which build.sh local installs with --no-cache.
+    - type: containerized
+      path: examples/transport/kafka
+    - type: containerized
+      path: examples/transport/nats

--- a/ak-py/pyproject.toml
+++ b/ak-py/pyproject.toml
@@ -76,6 +76,10 @@ kafka = [
     "confluent-kafka>=2.15.0",
 ]
 
+nats = [
+    "nats-py>=2.15.0",
+]
+
 thread = [
     "litellm>=1.74.9",
 ]

--- a/ak-py/src/agentkernel/core/config.py
+++ b/ak-py/src/agentkernel/core/config.py
@@ -390,6 +390,45 @@ class _KafkaQueueConfig(BaseModel):
     )
 
 
+class _NatsQueueConfig(BaseModel):
+    url: str = Field(default="nats://localhost:4222", description="NATS server URL (comma-separated for a cluster)")
+    input_stream: str = Field(default="AGENT_REQUESTS", description="JetStream stream carrying chat requests")
+    input_subject_prefix: str = Field(default="chat.req", description="Subject prefix for chat requests")
+    output_stream: str = Field(default="AGENT_REPLIES", description="JetStream stream carrying agent replies")
+    output_subject_prefix: str = Field(default="chat.out", description="Subject prefix for agent replies")
+    partitions: int = Field(
+        default=32,
+        description=(
+            "Number of partition subjects per stream, each served by its own durable consumer. Sessions hash to a "
+            "partition, so this caps how many messages can be in flight at once: keep it at or above "
+            "no_of_consumers x replicas. Changing it re-maps sessions, so size it up front (idle partitions cost "
+            "almost nothing)."
+        ),
+    )
+    ack_wait: float = Field(
+        default=300.0,
+        description=(
+            "Seconds the server waits for an acknowledgement before redelivering. Must exceed your longest agent "
+            "turn: a turn that outlives it is redelivered and executed a second time."
+        ),
+    )
+    retry_backoff: float = Field(default=2.0, description="Seconds to delay a redelivery after a failed message (nak delay)")
+    duplicate_window: float = Field(default=300.0, description="Seconds within which a repeated dedup id is dropped by the stream (SQS parity)")
+    max_age: float = Field(
+        default=86400.0,
+        description="Seconds before an unconsumed message is discarded. A safety net: work-queue messages are otherwise kept forever",
+    )
+    request_timeout: float = Field(default=10.0, description="Seconds to wait for a NATS request (publish, ack, management call) to complete")
+    auto_provision: bool = Field(
+        default=False,
+        description=(
+            "Create the streams and per-partition consumers at startup if missing. Convenient for local and dev "
+            "clusters; leave false in production, where the objects are managed declaratively (NACK CRs) and a "
+            "missing object should fail loudly instead of being created with defaults."
+        ),
+    )
+
+
 class _QueuesConfig(BaseModel):
     type: Optional[str] = Field(
         default=None,
@@ -403,6 +442,7 @@ class _QueuesConfig(BaseModel):
     output: _OutputQueueConfig = Field(default_factory=_OutputQueueConfig, description="Output queue configuration for queue execution mode")
     in_memory: Optional[_InMemoryQueueConfig] = Field(default=None, description="in_memory transport settings")
     kafka: Optional[_KafkaQueueConfig] = Field(default=None, description="kafka transport settings")
+    nats: Optional[_NatsQueueConfig] = Field(default=None, description="nats transport settings")
     batch_size: Optional[int] = Field(
         default=None,
         description=(

--- a/ak-py/src/agentkernel/pipeline/transport/base.py
+++ b/ak-py/src/agentkernel/pipeline/transport/base.py
@@ -90,10 +90,9 @@ class TransportConsumer(ABC):
 class QueueTransportFactory:
     """Resolves ``execution.queues.type`` to a transport (#541 house pattern).
 
-    ``in_memory``, ``sqs`` and ``kafka`` are available; ``nats`` arrives in a later #495
-    iteration, and selecting it before it lands raises :class:`AKConfigError`. Any other value is
-    treated as a dotted path to a :class:`QueueTransport` subclass (bring-your-own), which must
-    also implement ``create_consumer``.
+    All four built-ins are available: ``in_memory``, ``sqs``, ``kafka`` and ``nats``. Any other
+    value is treated as a dotted path to a :class:`QueueTransport` subclass (bring-your-own),
+    which must also implement ``create_consumer``.
     """
 
     _BUILTIN_TYPES = ("in_memory", "sqs", "kafka", "nats")
@@ -156,8 +155,43 @@ class QueueTransportFactory:
                 metadata_timeout=kafka_config.metadata_timeout,
                 client_config=kafka_config.client_config,
             )
+        if transport_type == "nats":
+            with require_extra("nats", "execution.queues.type: nats"):
+                from .nats import NatsTransport
+
+            queues = AKConfig.get().execution.queues
+            nats_config = getattr(queues, "nats", None) if queues is not None else None
+            if nats_config is None:
+                raise AKConfigError("the nats transport requires an execution.queues.nats configuration block")
+            return NatsTransport(
+                url=nats_config.url,
+                input_stream=nats_config.input_stream,
+                input_subject_prefix=nats_config.input_subject_prefix,
+                output_stream=nats_config.output_stream,
+                output_subject_prefix=nats_config.output_subject_prefix,
+                partitions=nats_config.partitions,
+                ack_wait=nats_config.ack_wait,
+                retry_backoff=nats_config.retry_backoff,
+                duplicate_window=nats_config.duplicate_window,
+                max_age=nats_config.max_age,
+                request_timeout=nats_config.request_timeout,
+                auto_provision=nats_config.auto_provision,
+                # The server ceiling sits one delivery above the loop's own limit, so the
+                # component's permanent-failure hook runs and the server is only the backstop.
+                max_deliver={
+                    QueueName.INPUT: queues.input.max_receive_count + 1,
+                    QueueName.OUTPUT: queues.output.max_receive_count + 1,
+                },
+            )
         if transport_type in cls._BUILTIN_TYPES:
-            raise AKConfigError(f"queue transport '{transport_type}' is not available yet (ships in a later #495 iteration)")
+            # Reachable only if a name is added to _BUILTIN_TYPES before its branch above: a clear
+            # error for the next transport author beats falling through to the dotted-path resolver.
+            raise AKConfigError(f"queue transport '{transport_type}' is listed as a built-in but has no implementation wired up")
+        if "." not in transport_type:
+            raise AKConfigError(
+                f"unknown queue transport '{transport_type}'; expected one of {list(cls._BUILTIN_TYPES)} "
+                "or a dotted path to a QueueTransport subclass"
+            )
         return resolve_dotted(transport_type, base=QueueTransport)()
 
     @classmethod

--- a/ak-py/src/agentkernel/pipeline/transport/nats.py
+++ b/ak-py/src/agentkernel/pipeline/transport/nats.py
@@ -1,0 +1,438 @@
+"""NATS JetStream queue transport (spec #495 §7).
+
+JetStream maps onto the pipeline's queue semantics more closely than any other broker here: the
+server itself provides the visibility timeout (``ack_wait``), the exact delivery count
+(``num_delivered``), a server-enforced delivery ceiling (``max_deliver``), publish-time
+deduplication (``Nats-Msg-Id`` plus the stream's duplicate window), and a terminal disposition
+(``term()``). Unlike Kafka, none of that has to be rebuilt, so this transport needs no bookkeeping
+store.
+
+Two things do need care:
+
+- **The client is asyncio-only.** The pipeline's consumers are threads, so every client coroutine
+  is dispatched onto one shared event loop running on a daemon thread (:class:`_NatsLoop`), the
+  pattern the NATS maintainers recommend for thread-based consumers. One connection multiplexes
+  every thread in the process.
+- **Per-session ordering is the DIY part.** JetStream has no equivalent of an SQS message group,
+  so sessions are hashed to a fixed number of partition subjects, each served by its own durable
+  consumer with ``max_ack_pending=1``. That gives one in-flight message per partition, ordered,
+  with partitions running in parallel: the same shape as the Kafka transport, except the server
+  enforces it rather than the client buffering to achieve it.
+"""
+
+import asyncio
+import logging
+import random
+import threading
+import time
+import zlib
+from typing import Any, Dict, List, Optional
+
+import nats
+from nats.errors import TimeoutError as NatsTimeoutError
+from nats.js.api import ConsumerConfig, RetentionPolicy, StreamConfig
+from nats.js.errors import NotFoundError
+
+from ...core.util.factory import AKConfigError
+from ..envelope import QueueMessage, QueueName
+from .base import QueueTransport, TransportConsumer
+
+_log = logging.getLogger("ak.pipeline.transport.nats")
+
+# JetStream's own deduplication header.
+MSG_ID_HEADER = "Nats-Msg-Id"
+# The session id travels as a header as well as a subject token: subject tokens cannot contain
+# dots, so the header is the authoritative value and the token is for routing and observability.
+GROUP_ID_HEADER = "Ak-Group-Id"
+
+# Floor on a single partition's fetch wait. Cycling many partitions with a tiny timeout each would
+# spend more time on round trips than on waiting for work.
+MIN_PARTITION_FETCH_SECONDS = 0.05
+
+
+class _NatsLoop:
+    """One asyncio event loop on a daemon thread, shared by every thread in the process.
+
+    ``nats-py`` has no synchronous API, and the pipeline's consumers are threads. Rather than each
+    thread owning a loop (and therefore a connection), coroutines are submitted to this single loop
+    and waited on with a timeout, which is the pattern the NATS maintainers publish for exactly
+    this situation.
+    """
+
+    _loop: Optional[asyncio.AbstractEventLoop] = None
+    _thread: Optional[threading.Thread] = None
+    _lock = threading.Lock()
+
+    @classmethod
+    def loop(cls) -> asyncio.AbstractEventLoop:
+        with cls._lock:
+            if cls._loop is None:
+                loop = asyncio.new_event_loop()
+                thread = threading.Thread(target=loop.run_forever, name="nats-event-loop", daemon=True)
+                thread.start()
+                cls._loop, cls._thread = loop, thread
+            return cls._loop
+
+    @classmethod
+    def run(cls, coro, timeout: float) -> Any:
+        """Run a coroutine on the shared loop and wait for its result.
+
+        :raises TimeoutError: if the coroutine does not finish within ``timeout``. The coroutine is
+            cancelled so a stalled call cannot leak work onto the loop.
+        """
+        future = asyncio.run_coroutine_threadsafe(coro, cls.loop())
+        try:
+            return future.result(timeout)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    @classmethod
+    def reset(cls) -> None:
+        """Stop the loop thread. Test isolation only."""
+        with cls._lock:
+            if cls._loop is not None:
+                cls._loop.call_soon_threadsafe(cls._loop.stop)
+            cls._loop, cls._thread = None, None
+
+
+class NatsTransportConsumer(TransportConsumer):
+    """Consumer over one stream's partition consumers. One instance per consumer thread.
+
+    A fetch cycles the partition subscriptions rather than watching one queue, because work is
+    spread across partitions and each partition allows a single in-flight message. The cursor
+    advances across calls and starts at a random offset per instance, so threads and replicas
+    neither converge on the same partition nor starve any of them.
+    """
+
+    def __init__(self, subscriptions: Dict[int, Any], request_timeout: float, retry_backoff: float, stream: str):
+        self._subscriptions = subscriptions
+        self._request_timeout = request_timeout
+        self._retry_backoff = retry_backoff
+        self._stream = stream
+        self._partitions = sorted(subscriptions)
+        self._cursor = random.randrange(len(self._partitions)) if self._partitions else 0
+
+    def fetch(self, batch_size: int, wait_seconds: float) -> List[QueueMessage]:
+        if not self._partitions:
+            return []
+
+        per_partition_wait = max(wait_seconds / len(self._partitions), MIN_PARTITION_FETCH_SECONDS)
+        deadline = time.monotonic() + wait_seconds
+        messages: List[QueueMessage] = []
+
+        for _ in range(len(self._partitions)):
+            if len(messages) >= batch_size or time.monotonic() >= deadline:
+                break
+            partition = self._partitions[self._cursor % len(self._partitions)]
+            self._cursor += 1
+            messages.extend(self._fetch_partition(partition, batch_size - len(messages), per_partition_wait))
+        return messages
+
+    def ack(self, message: QueueMessage) -> None:
+        _NatsLoop.run(message.native.ack(), self._request_timeout)
+
+    def nack(self, message: QueueMessage) -> None:
+        """Return the message for redelivery after the configured delay.
+
+        The server owns the redelivery, so unlike Kafka there is nothing to hold locally and the
+        consumer thread does not sleep out the backoff.
+        """
+        _NatsLoop.run(message.native.nak(delay=self._retry_backoff), self._request_timeout)
+
+    def dead_letter(self, message: QueueMessage) -> None:
+        """Terminate delivery of a message that exhausted its retries.
+
+        ``term()`` is JetStream's terminal disposition: it stops redelivery and removes the message
+        from the work-queue stream, which a plain ack would also do but without recording intent.
+        The server's ``max_deliver`` is the backstop if this never runs. The component's
+        permanent-failure hook has already delivered the error to the caller, so no dead-letter
+        stream is needed to avoid losing the response.
+        """
+        try:
+            _NatsLoop.run(message.native.term(), self._request_timeout)
+            _log.warning(f"Terminated message {message.message_id} on stream {self._stream} after {message.receive_count} deliveries")
+        except Exception:
+            # A failed term leaves the server to stop redelivery at max_deliver, so the message
+            # cannot loop forever; log and move on rather than blocking the consumer.
+            _log.exception(f"Failed to terminate message {message.message_id} on stream {self._stream}")
+
+    def close(self) -> None:
+        for partition, subscription in self._subscriptions.items():
+            try:
+                _NatsLoop.run(subscription.unsubscribe(), self._request_timeout)
+            except Exception:
+                _log.debug(f"Failed to unsubscribe partition {partition} of {self._stream}", exc_info=True)
+        self._subscriptions = {}
+        self._partitions = []
+
+    # -- internals ---------------------------------------------------------------------------
+
+    def _fetch_partition(self, partition: int, batch_size: int, wait_seconds: float) -> List[QueueMessage]:
+        subscription = self._subscriptions[partition]
+        try:
+            raw = _NatsLoop.run(subscription.fetch(batch=max(batch_size, 1), timeout=wait_seconds), wait_seconds + self._request_timeout)
+        except (NatsTimeoutError, TimeoutError):
+            return []  # an idle partition, which is the common case when work is sparse
+        return [self._to_envelope(message) for message in raw]
+
+    @staticmethod
+    def _to_envelope(message: Any) -> QueueMessage:
+        headers = dict(message.headers or {})
+        dedup_id = headers.pop(MSG_ID_HEADER, None)
+        group_id = headers.pop(GROUP_ID_HEADER, None)
+        metadata = message.metadata
+        return QueueMessage(
+            body=message.data.decode() if isinstance(message.data, (bytes, bytearray)) else (message.data or ""),
+            attributes=headers,
+            group_id=group_id,
+            dedup_id=dedup_id,
+            # num_delivered is 1 on the first delivery, matching the envelope's contract exactly.
+            receive_count=metadata.num_delivered,
+            message_id=f"{metadata.stream}:{metadata.sequence.stream}",
+            native=message,
+        )
+
+
+class NatsTransport(QueueTransport):
+    """JetStream-backed queue transport: the recommended on-prem broker for the pipeline.
+
+    Streams and partition consumers are provisioned once per process (when ``auto_provision`` is
+    on) or verified and reported as missing (when it is off, which is the production posture).
+    """
+
+    _connections: Dict[str, Any] = {}
+    _connections_lock = threading.Lock()
+    _provisioned: set = set()
+    _provisioned_lock = threading.Lock()
+
+    def __init__(
+        self,
+        url: str,
+        input_stream: str,
+        input_subject_prefix: str,
+        output_stream: str,
+        output_subject_prefix: str,
+        partitions: int = 32,
+        ack_wait: float = 300.0,
+        retry_backoff: float = 2.0,
+        duplicate_window: float = 300.0,
+        max_age: float = 86400.0,
+        request_timeout: float = 10.0,
+        auto_provision: bool = False,
+        max_deliver: Optional[Dict[QueueName, int]] = None,
+    ):
+        if partitions < 1:
+            raise AKConfigError(f"execution.queues.nats.partitions must be >= 1, got {partitions}")
+        self._url = url
+        self._streams = {QueueName.INPUT: input_stream, QueueName.OUTPUT: output_stream}
+        self._prefixes = {QueueName.INPUT: input_subject_prefix, QueueName.OUTPUT: output_subject_prefix}
+        self._partitions = partitions
+        self._ack_wait = ack_wait
+        self._retry_backoff = retry_backoff
+        self._duplicate_window = duplicate_window
+        self._max_age = max_age
+        self._request_timeout = request_timeout
+        self._auto_provision = auto_provision
+        # Server-side delivery ceiling per queue: one more than the loop's own limit, so the client
+        # hook runs on the last delivery and the server is only the backstop behind it.
+        self._max_deliver = max_deliver or {}
+
+    # -- send side ---------------------------------------------------------------------------
+
+    def send(self, queue: QueueName, message: QueueMessage) -> Any:
+        """Publish to the session's partition subject and wait for the stream's acknowledgement."""
+        self._ensure_provisioned(queue)
+
+        headers = {name: str(value) for name, value in message.attributes.items()}
+        if message.dedup_id:
+            headers[MSG_ID_HEADER] = message.dedup_id
+        if message.group_id:
+            headers[GROUP_ID_HEADER] = message.group_id
+
+        subject = self.subject_for(queue, message.group_id)
+        ack = _NatsLoop.run(
+            self._jetstream().publish(subject, message.body.encode(), headers=headers or None),
+            self._request_timeout,
+        )
+        # A duplicate is not an error: the stream's window rejected a repeat of a dedup id, which
+        # is the behaviour the pipeline asks for.
+        if getattr(ack, "duplicate", False):
+            _log.info(f"Stream {self._streams[queue]} dropped a duplicate publish (dedup_id={message.dedup_id})")
+        return {"MessageId": f"{self._streams[queue]}:{getattr(ack, 'seq', '')}"}
+
+    def subject_for(self, queue: QueueName, group_id: Optional[str]) -> str:
+        """The partition subject a session's messages travel on."""
+        partition = self.partition_for(group_id)
+        return f"{self._prefixes[queue]}.{partition}.{_subject_token(group_id)}"
+
+    def partition_for(self, group_id: Optional[str]) -> int:
+        """Map a session to a partition with a hash that is stable across processes.
+
+        Deliberately not Python's ``hash()``: string hashing is salted per interpreter, so two pods
+        would disagree about a session's partition and its ordering guarantee would evaporate.
+        """
+        if not group_id:
+            return 0
+        return zlib.crc32(group_id.encode()) % self._partitions
+
+    # -- receive side ------------------------------------------------------------------------
+
+    def create_consumer(self, queue: QueueName) -> NatsTransportConsumer:
+        self._ensure_provisioned(queue)
+        stream = self._streams[queue]
+        subscriptions = {
+            partition: _NatsLoop.run(
+                self._jetstream().pull_subscribe_bind(durable=self._durable_name(stream, partition), stream=stream),
+                self._request_timeout,
+            )
+            for partition in range(self._partitions)
+        }
+        return NatsTransportConsumer(
+            subscriptions=subscriptions,
+            request_timeout=self._request_timeout,
+            retry_backoff=self._retry_backoff,
+            stream=stream,
+        )
+
+    def check_consumer_capacity(self, queue: QueueName, num_consumers: int) -> None:
+        """Warn when partitions cannot keep the configured consumers busy.
+
+        Each partition consumer allows one in-flight message, so the partition count is the ceiling
+        on concurrent work no matter how many threads or replicas are polling.
+        """
+        if self._partitions < num_consumers:
+            _log.warning(
+                f"Stream {self._streams[queue]} has {self._partitions} partition(s) but {num_consumers} consumer(s) are "
+                f"configured for it: only {self._partitions} message(s) can be in flight at once, because each "
+                "partition consumer allows one. Raise execution.queues.nats.partitions or lower "
+                f"execution.queues.{queue.value}.no_of_consumers (note that changing partitions re-maps sessions)."
+            )
+        else:
+            _log.info(f"Stream {self._streams[queue]}: {self._partitions} partition(s) for {num_consumers} configured consumer(s)")
+
+    # -- provisioning ------------------------------------------------------------------------
+
+    def _ensure_provisioned(self, queue: QueueName) -> None:
+        """Create or verify the stream and its partition consumers, once per process per stream."""
+        stream = self._streams[queue]
+        cache_key = f"{self._url}:{stream}"
+        with self._provisioned_lock:
+            if cache_key in self._provisioned:
+                return
+            self._provisioned.add(cache_key)
+
+        try:
+            if self._auto_provision:
+                self._provision(queue, stream)
+            else:
+                self._verify(queue, stream)
+        except Exception:
+            # A failed attempt must not be remembered as done, or the next call would skip it and
+            # fail somewhere less obvious.
+            with self._provisioned_lock:
+                self._provisioned.discard(cache_key)
+            raise
+
+    def _provision(self, queue: QueueName, stream: str) -> None:
+        jetstream = self._jetstream()
+        subjects = [f"{self._prefixes[queue]}.>"]
+        try:
+            _NatsLoop.run(jetstream.stream_info(stream), self._request_timeout)
+        except NotFoundError:
+            _log.info(f"Creating JetStream stream {stream} for subjects {subjects}")
+            _NatsLoop.run(
+                jetstream.add_stream(
+                    StreamConfig(
+                        name=stream,
+                        subjects=subjects,
+                        # Work-queue retention is the closest match to SQS: a terminal ack removes
+                        # the message. max_age is the safety net, since an unconsumed work-queue
+                        # message is otherwise kept forever.
+                        retention=RetentionPolicy.WORK_QUEUE,
+                        duplicate_window=self._duplicate_window,
+                        max_age=self._max_age,
+                    )
+                ),
+                self._request_timeout,
+            )
+
+        for partition in range(self._partitions):
+            durable = self._durable_name(stream, partition)
+            try:
+                _NatsLoop.run(jetstream.consumer_info(stream, durable), self._request_timeout)
+            except NotFoundError:
+                _NatsLoop.run(jetstream.add_consumer(stream, config=self._consumer_config(queue, partition)), self._request_timeout)
+        _log.info(f"Stream {stream} provisioned with {self._partitions} partition consumer(s)")
+
+    def _verify(self, queue: QueueName, stream: str) -> None:
+        jetstream = self._jetstream()
+        try:
+            _NatsLoop.run(jetstream.stream_info(stream), self._request_timeout)
+        except NotFoundError as e:
+            raise AKConfigError(
+                f"JetStream stream '{stream}' does not exist. Create it (a NACK Stream CR, or the nats CLI) or set "
+                "execution.queues.nats.auto_provision: true to have Agent Kernel create it at startup."
+            ) from e
+
+        missing = []
+        for partition in range(self._partitions):
+            durable = self._durable_name(stream, partition)
+            try:
+                _NatsLoop.run(jetstream.consumer_info(stream, durable), self._request_timeout)
+            except NotFoundError:
+                missing.append(durable)
+        if missing:
+            raise AKConfigError(
+                f"JetStream stream '{stream}' is missing {len(missing)} of {self._partitions} partition consumer(s), "
+                f"starting with '{missing[0]}'. Create them (NACK Consumer CRs) or set "
+                "execution.queues.nats.auto_provision: true. Each consumer filters "
+                f"'{self._prefixes[queue]}.<partition>.>' with max_ack_pending=1."
+            )
+
+    def _consumer_config(self, queue: QueueName, partition: int) -> ConsumerConfig:
+        return ConsumerConfig(
+            durable_name=self._durable_name(self._streams[queue], partition),
+            # Non-overlapping filters are a hard requirement on a work-queue stream.
+            filter_subject=f"{self._prefixes[queue]}.{partition}.>",
+            ack_wait=self._ack_wait,
+            # Defaults to the loop's default max_receive_count (3) plus one when the caller did not
+            # supply a ceiling, so the server never cuts delivery short of the client's own limit.
+            max_deliver=self._max_deliver.get(queue, 4),
+            # The whole point of partitioning: one message at a time per partition keeps a
+            # session's turns ordered while other partitions run in parallel.
+            max_ack_pending=1,
+        )
+
+    @staticmethod
+    def _durable_name(stream: str, partition: int) -> str:
+        return f"{stream}-p{partition}"
+
+    # -- connection --------------------------------------------------------------------------
+
+    def _jetstream(self) -> Any:
+        return self._client().jetstream()
+
+    def _client(self) -> Any:
+        with self._connections_lock:
+            client = self._connections.get(self._url)
+            if client is None or not getattr(client, "is_connected", False):
+                _log.info(f"Connecting to NATS at {self._url}")
+                client = _NatsLoop.run(nats.connect(servers=self._url.split(",")), self._request_timeout)
+                self._connections[self._url] = client
+            return client
+
+    @classmethod
+    def reset(cls) -> None:
+        """Drop the process-wide connection cache and provisioning latch. Test isolation only."""
+        with cls._connections_lock:
+            cls._connections.clear()
+        with cls._provisioned_lock:
+            cls._provisioned.clear()
+
+
+def _subject_token(group_id: Optional[str]) -> str:
+    """Make a session id safe as a single subject token (no dots, spaces, or wildcards)."""
+    if not group_id:
+        return "_"
+    return "".join("_" if character in ".* >\t" else character for character in group_id)

--- a/ak-py/src/agentkernel/pipeline/transport/nats.py
+++ b/ak-py/src/agentkernel/pipeline/transport/nats.py
@@ -203,7 +203,10 @@ class NatsTransport(QueueTransport):
 
     _connections: Dict[str, Any] = {}
     _connections_lock = threading.Lock()
+    # Streams whose provisioning has *completed*, plus one lock per stream so concurrent callers
+    # for the same stream queue up instead of racing (see _ensure_provisioned).
     _provisioned: set = set()
+    _provision_locks: Dict[str, threading.Lock] = {}
     _provisioned_lock = threading.Lock()
 
     def __init__(
@@ -314,25 +317,35 @@ class NatsTransport(QueueTransport):
     # -- provisioning ------------------------------------------------------------------------
 
     def _ensure_provisioned(self, queue: QueueName) -> None:
-        """Create or verify the stream and its partition consumers, once per process per stream."""
+        """Create or verify the stream and its partition consumers, once per process per stream.
+
+        The stream is recorded as provisioned only after the work has actually finished, and callers
+        for the same stream queue behind one lock. Both matter because a pipeline component starts
+        several consumer threads at once: if a thread could see the record while another was still
+        creating the objects, it would race ahead to ``pull_subscribe_bind`` and die on a consumer
+        that does not exist yet. Locking per stream rather than globally lets the input and output
+        streams provision concurrently.
+        """
         stream = self._streams[queue]
         cache_key = f"{self._url}:{stream}"
         with self._provisioned_lock:
             if cache_key in self._provisioned:
                 return
-            self._provisioned.add(cache_key)
+            provision_lock = self._provision_locks.setdefault(cache_key, threading.Lock())
 
-        try:
+        with provision_lock:
+            if cache_key in self._provisioned:
+                return  # another thread finished the work while this one waited for the lock
+
             if self._auto_provision:
                 self._provision(queue, stream)
             else:
                 self._verify(queue, stream)
-        except Exception:
-            # A failed attempt must not be remembered as done, or the next call would skip it and
-            # fail somewhere less obvious.
+
+            # Only now: a failure leaves the stream unrecorded so the next call retries instead of
+            # skipping and failing somewhere less obvious.
             with self._provisioned_lock:
-                self._provisioned.discard(cache_key)
-            raise
+                self._provisioned.add(cache_key)
 
     def _provision(self, queue: QueueName, stream: str) -> None:
         jetstream = self._jetstream()
@@ -418,9 +431,18 @@ class NatsTransport(QueueTransport):
             client = self._connections.get(self._url)
             if client is None or not getattr(client, "is_connected", False):
                 _log.info(f"Connecting to NATS at {self._url}")
-                client = _NatsLoop.run(nats.connect(servers=self._url.split(",")), self._request_timeout)
+                client = _NatsLoop.run(nats.connect(servers=self._server_list()), self._request_timeout)
                 self._connections[self._url] = client
             return client
+
+    def _server_list(self) -> List[str]:
+        """Split the configured URL into servers, tolerating spaces around the commas.
+
+        ``url`` is documented as comma-separated for a cluster, and writing it with spaces after the
+        commas is natural; an untrimmed entry would be handed to the client verbatim and fail to
+        connect.
+        """
+        return [server.strip() for server in self._url.split(",") if server.strip()]
 
     @classmethod
     def reset(cls) -> None:
@@ -429,6 +451,7 @@ class NatsTransport(QueueTransport):
             cls._connections.clear()
         with cls._provisioned_lock:
             cls._provisioned.clear()
+            cls._provision_locks.clear()
 
 
 def _subject_token(group_id: Optional[str]) -> str:

--- a/ak-py/tests/test_pipeline_consumer_loop.py
+++ b/ak-py/tests/test_pipeline_consumer_loop.py
@@ -223,17 +223,34 @@ class TestTransportFactory:
         monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: self._FakeCfgNoTypeNoUrl))
         assert isinstance(QueueTransportFactory.create(), InMemoryTransport)
 
-    def test_builtin_not_yet_available_raises(self, monkeypatch):
+    def test_builtin_without_an_implementation_raises(self, monkeypatch):
+        """Every built-in now ships, so this guards the next one: a name added to _BUILTIN_TYPES
+        before its factory branch must say so rather than fall through to the dotted-path resolver."""
+
         class _Cfg:
             class execution:
                 class queues:
-                    type = "nats"  # the last built-in still to land; kafka shipped in iteration 7
+                    type = "rabbitmq"
 
                     class input:
                         url = None
 
         monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: _Cfg))
-        with pytest.raises(AKConfigError, match="not available yet"):
+        monkeypatch.setattr(QueueTransportFactory, "_BUILTIN_TYPES", ("in_memory", "sqs", "kafka", "nats", "rabbitmq"))
+        with pytest.raises(AKConfigError, match="no implementation wired up"):
+            QueueTransportFactory.create()
+
+    def test_unknown_type_lists_the_valid_options(self, monkeypatch):
+        class _Cfg:
+            class execution:
+                class queues:
+                    type = "bogus"
+
+                    class input:
+                        url = None
+
+        monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: _Cfg))
+        with pytest.raises(AKConfigError, match="expected one of"):
             QueueTransportFactory.create()
 
     def test_dotted_path_resolves_byo_transport(self, monkeypatch):

--- a/ak-py/tests/test_pipeline_nats_transport.py
+++ b/ak-py/tests/test_pipeline_nats_transport.py
@@ -1,0 +1,567 @@
+"""NATS JetStream transport (spec #495 §7) over a fake JetStream.
+
+The fake replaces the client, not the bridge: every call still crosses :class:`_NatsLoop`'s real
+event-loop thread via ``run_coroutine_threadsafe``, so the threading path this transport depends on
+is exercised rather than mocked away. The fake models the JetStream behaviours the transport leans
+on: work-queue delivery with one in-flight message per partition consumer (``max_ack_pending=1``),
+``num_delivered`` counting, nak redelivery, term, and stream-scoped dedup on ``Nats-Msg-Id``.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import pytest
+from nats.errors import TimeoutError as NatsTimeoutError
+from nats.js.errors import NotFoundError
+
+from agentkernel.core.util.factory import AKConfigError
+from agentkernel.pipeline.envelope import QueueMessage, QueueName
+from agentkernel.pipeline.testing import QueueTransportContract
+from agentkernel.pipeline.transport import nats as nats_module
+from agentkernel.pipeline.transport.base import QueueTransportFactory
+from agentkernel.pipeline.transport.nats import GROUP_ID_HEADER, MSG_ID_HEADER, NatsTransport, _NatsLoop
+
+URL = "nats://localhost:4222"
+INPUT_STREAM = "AGENT_REQUESTS"
+OUTPUT_STREAM = "AGENT_REPLIES"
+INPUT_PREFIX = "chat.req"
+OUTPUT_PREFIX = "chat.out"
+PARTITIONS = 4
+
+
+class FakeSequence:
+    def __init__(self, stream: int):
+        self.stream = stream
+
+
+class FakeMetadata:
+    def __init__(self, stream: str, sequence: int, num_delivered: int):
+        self.stream = stream
+        self.sequence = FakeSequence(sequence)
+        self.num_delivered = num_delivered
+
+
+class FakeMsg:
+    """A JetStream message with the ack/nak/term surface the transport uses."""
+
+    def __init__(self, stream_state: "FakeStream", record: dict, num_delivered: int):
+        self._stream_state = stream_state
+        self._record = record
+        self.data = record["data"]
+        self.headers = dict(record["headers"] or {})
+        self.subject = record["subject"]
+        self.metadata = FakeMetadata(stream_state.name, record["seq"], num_delivered)
+
+    async def ack(self) -> None:
+        self._stream_state.finish(self._record)
+
+    async def nak(self, delay: float = 0) -> None:
+        self._record["nak_delay"] = delay
+        self._stream_state.release(self._record)
+
+    async def term(self) -> None:
+        self._record["terminated"] = True
+        self._stream_state.finish(self._record)
+
+    async def in_progress(self) -> None:
+        return None
+
+
+class FakeStream:
+    """One work-queue stream: per-partition FIFO, one in-flight message per partition, dedup."""
+
+    def __init__(self, name: str, subjects: List[str], ack_wait: float = 2.0):
+        self.name = name
+        self.subjects = subjects
+        self.ack_wait = ack_wait
+        self.records: List[dict] = []
+        self.in_flight: Dict[int, dict] = {}  # partition -> record
+        self.dedup_ids: set = set()
+        self.consumers: Dict[str, Any] = {}
+        self._seq = 0
+        self._lock = threading.Lock()
+
+    def publish(self, subject: str, data: bytes, headers: Optional[dict]) -> dict:
+        with self._lock:
+            dedup_id = (headers or {}).get(MSG_ID_HEADER)
+            if dedup_id is not None and dedup_id in self.dedup_ids:
+                return {"seq": 0, "duplicate": True}
+            if dedup_id is not None:
+                self.dedup_ids.add(dedup_id)
+            self._seq += 1
+            record = {
+                "seq": self._seq,
+                "subject": subject,
+                "data": data,
+                "headers": headers,
+                "partition": int(subject.split(".")[2]),
+                "deliveries": 0,
+                "done": False,
+            }
+            self.records.append(record)
+            return {"seq": self._seq, "duplicate": False}
+
+    def next_for(self, partition: int) -> Optional[FakeMsg]:
+        with self._lock:
+            held = self.in_flight.get(partition)
+            if held is not None and time.monotonic() >= held["deadline"]:
+                self.in_flight.pop(partition)  # ack_wait elapsed: the server redelivers
+                held = None
+            if held is not None:
+                return None  # max_ack_pending=1
+            for record in self.records:
+                if record["done"] or record["partition"] != partition:
+                    continue
+                record["deliveries"] += 1
+                record["deadline"] = time.monotonic() + self.ack_wait
+                self.in_flight[partition] = record
+                return FakeMsg(self, record, record["deliveries"])
+            return None
+
+    def finish(self, record: dict) -> None:
+        with self._lock:
+            record["done"] = True
+            self.in_flight.pop(record["partition"], None)
+
+    def release(self, record: dict) -> None:
+        with self._lock:
+            self.in_flight.pop(record["partition"], None)
+
+    def pending(self) -> List[dict]:
+        return [record for record in self.records if not record["done"]]
+
+
+class FakePullSubscription:
+    def __init__(self, stream: FakeStream, partition: int):
+        self._stream = stream
+        self._partition = partition
+        self.unsubscribed = False
+
+    async def fetch(self, batch: int = 1, timeout: float = 1.0) -> List[FakeMsg]:
+        messages = []
+        while len(messages) < batch:
+            message = self._stream.next_for(self._partition)
+            if message is None:
+                break
+            messages.append(message)
+        if not messages:
+            raise NatsTimeoutError
+        return messages
+
+    async def unsubscribe(self) -> None:
+        self.unsubscribed = True
+
+
+class FakeJetStream:
+    def __init__(self, server: "FakeNatsServer"):
+        self._server = server
+
+    async def publish(self, subject: str, payload: bytes, headers=None):
+        stream = self._server.stream_for_subject(subject)
+        if stream is None:
+            raise NotFoundError
+        result = stream.publish(subject, payload, headers)
+
+        class Ack:
+            seq = result["seq"]
+            duplicate = result["duplicate"]
+
+        return Ack()
+
+    async def stream_info(self, name: str):
+        if name not in self._server.streams:
+            raise NotFoundError
+        return self._server.streams[name]
+
+    async def add_stream(self, config):
+        self._server.streams[config.name] = FakeStream(config.name, list(config.subjects))
+        self._server.created_streams.append(config)
+        return self._server.streams[config.name]
+
+    async def consumer_info(self, stream: str, durable: str):
+        if stream not in self._server.streams or durable not in self._server.streams[stream].consumers:
+            raise NotFoundError
+        return self._server.streams[stream].consumers[durable]
+
+    async def add_consumer(self, stream: str, config):
+        self._server.streams[stream].consumers[config.durable_name] = config
+        self._server.created_consumers.append(config)
+        return config
+
+    async def pull_subscribe_bind(self, durable: str, stream: str):
+        stream_state = self._server.streams[stream]
+        if durable not in stream_state.consumers:
+            raise NotFoundError
+        partition = int(durable.rsplit("p", 1)[1])
+        return FakePullSubscription(stream_state, partition)
+
+
+class FakeClient:
+    def __init__(self, server: "FakeNatsServer"):
+        self._server = server
+        self.is_connected = True
+
+    def jetstream(self):
+        return FakeJetStream(self._server)
+
+
+class FakeNatsServer:
+    def __init__(self):
+        self.streams: Dict[str, FakeStream] = {}
+        self.created_streams: List[Any] = []
+        self.created_consumers: List[Any] = []
+        self.connect_calls = 0
+
+    def provision(self, name: str, prefix: str, partitions: int = PARTITIONS, ack_wait: float = 2.0) -> None:
+        """Pre-create a stream and its partition consumers, as NACK CRs would."""
+        stream = FakeStream(name, [f"{prefix}.>"], ack_wait=ack_wait)
+        for partition in range(partitions):
+            stream.consumers[f"{name}-p{partition}"] = object()
+        self.streams[name] = stream
+
+    def stream_for_subject(self, subject: str) -> Optional[FakeStream]:
+        for stream in self.streams.values():
+            for pattern in stream.subjects:
+                if subject.startswith(pattern.rstrip(">").rstrip(".")):
+                    return stream
+        return None
+
+
+@pytest.fixture
+def server(monkeypatch):
+    fake = FakeNatsServer()
+
+    async def _connect(servers=None, **kwargs):
+        fake.connect_calls += 1
+        return FakeClient(fake)
+
+    monkeypatch.setattr(nats_module.nats, "connect", _connect)
+    NatsTransport.reset()
+    yield fake
+    NatsTransport.reset()
+
+
+def _transport(server=None, **overrides) -> NatsTransport:
+    kwargs = {
+        "url": URL,
+        "input_stream": INPUT_STREAM,
+        "input_subject_prefix": INPUT_PREFIX,
+        "output_stream": OUTPUT_STREAM,
+        "output_subject_prefix": OUTPUT_PREFIX,
+        "partitions": PARTITIONS,
+        "retry_backoff": 0.0,
+        "request_timeout": 5.0,
+    }
+    kwargs.update(overrides)
+    return NatsTransport(**kwargs)
+
+
+def _provisioned(server) -> NatsTransport:
+    server.provision(INPUT_STREAM, INPUT_PREFIX)
+    server.provision(OUTPUT_STREAM, OUTPUT_PREFIX)
+    return _transport()
+
+
+class TestLoopBridge:
+    def test_coroutines_run_on_a_shared_daemon_loop(self):
+        async def where_am_i():
+            return threading.current_thread().name
+
+        assert _NatsLoop.run(where_am_i(), timeout=5) == "nats-event-loop"
+        assert _NatsLoop.run(where_am_i(), timeout=5) == "nats-event-loop", "the same loop is reused"
+
+    def test_a_stalled_call_times_out_and_is_cancelled(self):
+        started = threading.Event()
+
+        async def never_finishes():
+            started.set()
+            await asyncio.sleep(30)
+
+        with pytest.raises(TimeoutError):
+            _NatsLoop.run(never_finishes(), timeout=0.2)
+        assert started.is_set(), "the coroutine did start, so the timeout is the wait and not a scheduling failure"
+
+
+class TestSend:
+    def test_publish_carries_headers_and_partitioned_subject(self, server):
+        transport = _provisioned(server)
+        result = transport.send(
+            QueueName.INPUT,
+            QueueMessage(body='{"prompt": "hi"}', attributes={"request_id": "r1"}, group_id="s1", dedup_id="d1"),
+        )
+
+        [record] = server.streams[INPUT_STREAM].records
+        assert record["data"] == b'{"prompt": "hi"}'
+        assert record["headers"]["request_id"] == "r1"
+        assert record["headers"][MSG_ID_HEADER] == "d1", "the dedup id becomes the JetStream message id"
+        assert record["headers"][GROUP_ID_HEADER] == "s1", "the session id travels as a header, not only a subject token"
+        assert record["subject"] == f"{INPUT_PREFIX}.{transport.partition_for('s1')}.s1"
+        assert result["MessageId"] == f"{INPUT_STREAM}:1"
+
+    def test_sessions_map_to_stable_partitions(self, server):
+        transport = _provisioned(server)
+        first = transport.partition_for("session-abc")
+        assert first == transport.partition_for("session-abc"), "the same session always lands on one partition"
+        assert 0 <= first < PARTITIONS
+        assert {transport.partition_for(f"s{i}") for i in range(40)} == set(range(PARTITIONS)), "sessions spread over partitions"
+
+    def test_partition_hash_is_stable_across_processes(self, server):
+        """Not Python's hash(): string hashing is salted per interpreter, so two pods would
+        disagree about a session's partition and its ordering guarantee would be lost."""
+        transport = _provisioned(server)
+        # crc32 of "session-abc" is fixed for all time, so this value can be asserted literally.
+        import zlib
+
+        assert transport.partition_for("session-abc") == zlib.crc32(b"session-abc") % PARTITIONS
+
+    def test_session_ids_with_dots_stay_a_single_subject_token(self, server):
+        transport = _provisioned(server)
+        transport.send(QueueName.INPUT, QueueMessage(body="{}", group_id="tenant.a b"))
+        [record] = server.streams[INPUT_STREAM].records
+        assert record["subject"].count(".") == 3, "prefix has one dot, then partition, then one token"
+        assert record["headers"][GROUP_ID_HEADER] == "tenant.a b", "the header keeps the real value"
+
+    def test_output_goes_to_the_reply_stream(self, server):
+        transport = _provisioned(server)
+        transport.send(QueueName.OUTPUT, QueueMessage(body="reply", group_id="s1"))
+        assert len(server.streams[OUTPUT_STREAM].records) == 1
+        assert server.streams[INPUT_STREAM].records == []
+
+
+class TestConsume:
+    def test_envelope_mapping(self, server):
+        transport = _provisioned(server)
+        transport.send(QueueName.INPUT, QueueMessage(body="body", attributes={"request_id": "r1"}, group_id="s1", dedup_id="d1"))
+
+        [message] = transport.create_consumer(QueueName.INPUT).fetch(10, 1.0)
+
+        assert message.body == "body"
+        assert message.attributes == {"request_id": "r1"}, "the NATS and group-id headers are lifted out"
+        assert message.dedup_id == "d1"
+        assert message.group_id == "s1"
+        assert message.receive_count == 1, "num_delivered is 1 on the first delivery"
+        assert message.message_id == f"{INPUT_STREAM}:1"
+
+    def test_ack_removes_the_message(self, server):
+        transport = _provisioned(server)
+        transport.send(QueueName.INPUT, QueueMessage(body="body", group_id="s1"))
+        consumer = transport.create_consumer(QueueName.INPUT)
+
+        [message] = consumer.fetch(10, 1.0)
+        consumer.ack(message)
+
+        assert server.streams[INPUT_STREAM].pending() == []
+        assert consumer.fetch(10, 0.2) == []
+
+    def test_nack_redelivers_with_the_configured_delay(self, server):
+        transport = _provisioned(server)
+        transport.send(QueueName.INPUT, QueueMessage(body="body", group_id="s1"))
+        consumer = transport.create_consumer(QueueName.INPUT)
+
+        [message] = consumer.fetch(10, 1.0)
+        consumer.nack(message)
+
+        [record] = server.streams[INPUT_STREAM].pending()
+        assert record["nak_delay"] == 0.0, "the delay comes from retry_backoff"
+        [redelivered] = consumer.fetch(10, 1.0)
+        assert redelivered.receive_count == 2, "the server counts the delivery, not the client"
+
+    def test_dead_letter_terminates_delivery(self, server, caplog):
+        transport = _provisioned(server)
+        transport.send(QueueName.INPUT, QueueMessage(body="poison", group_id="s1"))
+        consumer = transport.create_consumer(QueueName.INPUT)
+        [message] = consumer.fetch(10, 1.0)
+
+        with caplog.at_level(logging.WARNING, logger="ak.pipeline.transport.nats"):
+            consumer.dead_letter(message)
+
+        [record] = server.streams[INPUT_STREAM].records
+        assert record["terminated"] is True, "term() records intent; a bare ack would not"
+        assert record["done"] is True
+        assert any("Terminated message" in entry.message for entry in caplog.records)
+
+    def test_one_message_in_flight_per_partition(self, server):
+        """max_ack_pending=1 is what keeps a session's turns ordered: the server withholds the
+        next message on that partition until the current one reaches a terminal state."""
+        transport = _provisioned(server)
+        transport.send(QueueName.INPUT, QueueMessage(body="first", group_id="s1"))
+        transport.send(QueueName.INPUT, QueueMessage(body="second", group_id="s1"))
+        consumer = transport.create_consumer(QueueName.INPUT)
+
+        [first] = consumer.fetch(10, 1.0)
+        assert first.body == "first"
+        assert consumer.fetch(10, 0.2) == [], "the next turn waits for the current one"
+
+        consumer.ack(first)
+        [second] = consumer.fetch(10, 1.0)
+        assert second.body == "second"
+
+    def test_close_unsubscribes_every_partition(self, server):
+        transport = _provisioned(server)
+        consumer = transport.create_consumer(QueueName.INPUT)
+        subscriptions = list(consumer._subscriptions.values())
+
+        consumer.close()
+
+        assert len(subscriptions) == PARTITIONS
+        assert all(subscription.unsubscribed for subscription in subscriptions)
+
+
+class TestDeduplication:
+    def test_repeated_dedup_id_is_dropped_by_the_stream(self, server):
+        transport = _provisioned(server)
+        transport.send(QueueName.INPUT, QueueMessage(body="m1", group_id="s1", dedup_id="d1"))
+        transport.send(QueueName.INPUT, QueueMessage(body="m1-again", group_id="s1", dedup_id="d1"))
+
+        assert len(server.streams[INPUT_STREAM].records) == 1, "the duplicate never enters the stream"
+
+    def test_a_reply_may_reuse_its_request_dedup_id(self, server):
+        """JetStream scopes the duplicate window per stream, and requests and replies live on
+        different streams, so the reply cannot be mistaken for a repeat of its request. The Kafka
+        transport had to scope its own claim by topic to get the same property."""
+        transport = _provisioned(server)
+        request_id = "req-1"
+
+        transport.send(QueueName.INPUT, QueueMessage(body="request", group_id="s1", dedup_id=request_id))
+        transport.send(QueueName.OUTPUT, QueueMessage(body="reply", group_id="s1", dedup_id=request_id))
+
+        assert len(server.streams[INPUT_STREAM].records) == 1
+        assert len(server.streams[OUTPUT_STREAM].records) == 1, "the reply survives its request's dedup id"
+
+
+class TestProvisioning:
+    def test_auto_provision_creates_the_stream_and_partition_consumers(self, server):
+        transport = _transport(auto_provision=True, max_deliver={QueueName.INPUT: 4})
+        transport.send(QueueName.INPUT, QueueMessage(body="{}", group_id="s1"))
+
+        [stream_config] = server.created_streams
+        assert stream_config.name == INPUT_STREAM
+        assert stream_config.subjects == [f"{INPUT_PREFIX}.>"]
+        assert stream_config.retention == nats_module.RetentionPolicy.WORK_QUEUE
+        assert stream_config.duplicate_window == 300.0
+
+        assert len(server.created_consumers) == PARTITIONS
+        first = server.created_consumers[0]
+        assert first.durable_name == f"{INPUT_STREAM}-p0"
+        assert first.filter_subject == f"{INPUT_PREFIX}.0.>", "non-overlapping filters are required on a work-queue stream"
+        assert first.max_ack_pending == 1
+        assert first.max_deliver == 4, "one above the loop's limit, so the client hook runs before the server cuts off"
+
+    def test_auto_provision_leaves_an_existing_stream_alone(self, server):
+        server.provision(INPUT_STREAM, INPUT_PREFIX)
+        _transport(auto_provision=True).send(QueueName.INPUT, QueueMessage(body="{}", group_id="s1"))
+        assert server.created_streams == [], "an operator-managed stream is not reconfigured"
+
+    def test_missing_stream_without_auto_provision_fails_loudly(self, server):
+        with pytest.raises(AKConfigError, match="does not exist"):
+            _transport().send(QueueName.INPUT, QueueMessage(body="{}", group_id="s1"))
+
+    def test_missing_consumers_without_auto_provision_name_the_gap(self, server):
+        # The stream exists but nothing created its partition consumers.
+        server.streams[INPUT_STREAM] = FakeStream(INPUT_STREAM, [f"{INPUT_PREFIX}.>"])
+
+        with pytest.raises(AKConfigError, match="partition consumer") as raised:
+            _transport().send(QueueName.INPUT, QueueMessage(body="{}", group_id="s1"))
+        assert f"{INPUT_STREAM}-p0" in str(raised.value), "the error names the first missing object"
+        assert "auto_provision" in str(raised.value), "and how to have Agent Kernel create it"
+
+    def test_provisioning_failure_is_retried_rather_than_cached(self, server):
+        transport = _transport()
+        with pytest.raises(AKConfigError):
+            transport.send(QueueName.INPUT, QueueMessage(body="{}", group_id="s1"))
+
+        server.provision(INPUT_STREAM, INPUT_PREFIX)
+        transport.send(QueueName.INPUT, QueueMessage(body="{}", group_id="s1"))
+        assert len(server.streams[INPUT_STREAM].records) == 1, "the second attempt provisions instead of skipping"
+
+    def test_rejects_a_partition_count_below_one(self, server):
+        with pytest.raises(AKConfigError, match="partitions"):
+            _transport(partitions=0)
+
+
+class TestConsumerCapacity:
+    def test_warns_when_partitions_cannot_keep_consumers_busy(self, server, caplog):
+        with caplog.at_level(logging.WARNING, logger="ak.pipeline.transport.nats"):
+            _transport(partitions=2).check_consumer_capacity(QueueName.INPUT, num_consumers=5)
+
+        [warning] = [record for record in caplog.records if record.levelname == "WARNING"]
+        assert "2 partition(s) but 5 consumer(s)" in warning.message
+        assert "re-maps sessions" in warning.message
+
+    def test_no_warning_when_partitions_are_sufficient(self, server, caplog):
+        with caplog.at_level(logging.INFO, logger="ak.pipeline.transport.nats"):
+            _transport(partitions=32).check_consumer_capacity(QueueName.INPUT, num_consumers=5)
+        assert [record for record in caplog.records if record.levelname == "WARNING"] == []
+
+
+class TestFactory:
+    @staticmethod
+    def _cfg():
+        class _Nats:
+            url = URL
+            input_stream = INPUT_STREAM
+            input_subject_prefix = INPUT_PREFIX
+            output_stream = OUTPUT_STREAM
+            output_subject_prefix = OUTPUT_PREFIX
+            partitions = 8
+            ack_wait = 300.0
+            retry_backoff = 2.0
+            duplicate_window = 300.0
+            max_age = 86400.0
+            request_timeout = 10.0
+            auto_provision = True
+
+        class _Cfg:
+            class execution:
+                class queues:
+                    type = "nats"
+                    nats = _Nats
+
+                    class input:
+                        url = None
+                        max_receive_count = 2
+
+                    class output:
+                        max_receive_count = 3
+
+        return _Cfg
+
+    def test_type_nats_builds_the_transport_from_config(self, server, monkeypatch):
+        monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: self._cfg()))
+        transport = QueueTransportFactory.create()
+
+        assert isinstance(transport, NatsTransport)
+        assert transport._partitions == 8
+        assert transport._auto_provision is True
+        assert transport._max_deliver == {
+            QueueName.INPUT: 3,
+            QueueName.OUTPUT: 4,
+        }, "the server ceiling sits one delivery above each queue's max_receive_count"
+
+    def test_missing_nats_block_raises(self, server, monkeypatch):
+        cfg = self._cfg()
+        cfg.execution.queues.nats = None
+        monkeypatch.setattr("agentkernel.core.config.AKConfig.get", classmethod(lambda cls: cfg))
+        with pytest.raises(AKConfigError, match="execution.queues.nats"):
+            QueueTransportFactory.create()
+
+
+class TestNatsTransportContract(QueueTransportContract):
+    """The shared transport contract against JetStream semantics."""
+
+    ack_wait = 0.3
+
+    @pytest.fixture(autouse=True)
+    def _provisioned_server(self, server):
+        server.provision(INPUT_STREAM, INPUT_PREFIX, ack_wait=self.ack_wait)
+        server.provision(OUTPUT_STREAM, OUTPUT_PREFIX, ack_wait=self.ack_wait)
+        self._server = server
+
+    # timeout_redelivery stays True, unlike Kafka: ack_wait is a real visibility timeout, so the
+    # contract's unacked-redelivery case genuinely applies here.
+
+    def make_transport(self) -> NatsTransport:
+        return _transport()

--- a/ak-py/tests/test_pipeline_nats_transport.py
+++ b/ak-py/tests/test_pipeline_nats_transport.py
@@ -481,6 +481,73 @@ class TestProvisioning:
         with pytest.raises(AKConfigError, match="partitions"):
             _transport(partitions=0)
 
+    def test_concurrent_callers_never_see_a_half_provisioned_stream(self, server):
+        """A component starts several consumer threads at once. If a thread could observe the
+        stream as provisioned while another was still creating it, it would race ahead to
+        pull_subscribe_bind and die on a consumer that does not exist yet."""
+        slow_add_consumer = FakeJetStream.add_consumer
+        observed_during_provisioning = []
+
+        async def add_consumer_slowly(self, stream, config):
+            # While provisioning is mid-flight, record what a second thread would conclude.
+            observed_during_provisioning.append(f"{URL}:{INPUT_STREAM}" in NatsTransport._provisioned)
+            await asyncio.sleep(0.02)
+            return await slow_add_consumer(self, stream, config)
+
+        FakeJetStream.add_consumer = add_consumer_slowly
+        try:
+            transport = _transport(auto_provision=True)
+            consumers = []
+            errors = []
+
+            def create():
+                try:
+                    consumers.append(transport.create_consumer(QueueName.INPUT))
+                except Exception as e:  # a race would surface as NotFoundError from the bind
+                    errors.append(e)
+
+            threads = [threading.Thread(target=create) for _ in range(4)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=30)
+        finally:
+            FakeJetStream.add_consumer = slow_add_consumer
+
+        assert errors == [], f"a concurrent caller failed: {errors}"
+        assert len(consumers) == 4
+        assert not any(observed_during_provisioning), "the stream was advertised as provisioned before the work finished"
+        assert len(server.created_consumers) == PARTITIONS, "the work happened exactly once despite four callers"
+
+
+class TestServerList:
+    """`url` is documented as comma-separated for a cluster, so the entries have to survive the
+    spacing people actually write."""
+
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            ("nats://a:4222", ["nats://a:4222"]),
+            ("nats://a:4222,nats://b:4222", ["nats://a:4222", "nats://b:4222"]),
+            ("nats://a:4222, nats://b:4222", ["nats://a:4222", "nats://b:4222"]),
+            (" nats://a:4222 , nats://b:4222 ", ["nats://a:4222", "nats://b:4222"]),
+            ("nats://a:4222,,nats://b:4222,", ["nats://a:4222", "nats://b:4222"]),
+        ],
+    )
+    def test_cluster_urls_are_split_and_trimmed(self, server, url, expected):
+        assert _transport(url=url)._server_list() == expected
+
+    def test_the_connection_uses_the_parsed_list(self, server, monkeypatch):
+        captured = {}
+
+        async def _connect(servers=None, **kwargs):
+            captured["servers"] = servers
+            return FakeClient(server)
+
+        monkeypatch.setattr(nats_module.nats, "connect", _connect)
+        _transport(url="nats://a:4222, nats://b:4222")._client()
+        assert captured["servers"] == ["nats://a:4222", "nats://b:4222"], "an untrimmed entry would fail to connect"
+
 
 class TestConsumerCapacity:
     def test_warns_when_partitions_cannot_keep_consumers_busy(self, server, caplog):

--- a/ak-py/uv.lock
+++ b/ak-py/uv.lock
@@ -125,6 +125,9 @@ multimodal = [
     { name = "litellm" },
     { name = "python-multipart" },
 ]
+nats = [
+    { name = "nats-py" },
+]
 neo4j = [
     { name = "neo4j" },
 ]
@@ -242,6 +245,7 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'thread'", specifier = ">=1.74.9" },
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=3.0" },
     { name = "msal", marker = "extra == 'teams'", specifier = ">=1.31.1" },
+    { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.15.0" },
     { name = "neo4j", marker = "extra == 'neo4j'", specifier = ">=5.0.0" },
     { name = "nest-asyncio", marker = "extra == 'langfuse'", specifier = ">=1.6.0" },
     { name = "openai-agents", marker = "extra == 'openai'", specifier = ">=0.6.5" },
@@ -275,7 +279,7 @@ requires-dist = [
     { name = "valkey", marker = "extra == 'valkey'", specifier = ">=6.0.0" },
     { name = "walledai", marker = "extra == 'walledai'", specifier = ">=4.9.3" },
 ]
-provides-extras = ["auth", "langfuse", "openllmetry", "logfire", "crewai", "langgraph", "smolagents", "pydanticai", "cli", "aws", "azure", "redis", "valkey", "kafka", "thread", "neo4j", "chromadb", "trino", "openai", "adk", "walledai", "api", "slack", "whatsapp", "messenger", "instagram", "telegram", "teams", "gmail", "gcp", "test", "a2a", "mcp", "multimodal", "sandbox-docker", "e2b", "daytona"]
+provides-extras = ["auth", "langfuse", "openllmetry", "logfire", "crewai", "langgraph", "smolagents", "pydanticai", "cli", "aws", "azure", "redis", "valkey", "kafka", "nats", "thread", "neo4j", "chromadb", "trino", "openai", "adk", "walledai", "api", "slack", "whatsapp", "messenger", "instagram", "telegram", "teams", "gmail", "gcp", "test", "a2a", "mcp", "multimodal", "sandbox-docker", "e2b", "daytona"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3496,6 +3500,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
+name = "nats-py"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f0/fc5e93f2b0dd14a202590ad9d30eda1955ea872039b5204357348d0f4b1e/nats_py-2.15.0.tar.gz", hash = "sha256:6622c547d9a7d2313d9c147d46c386188f4ec2c7b5c9f9a0438a4d1b55f54a93", size = 75995, upload-time = "2026-06-05T07:34:03.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/a8/b55606c7c621fb813c8ec78baf201d2c78bf6051091ec0c7ada572999e95/nats_py-2.15.0-py3-none-any.whl", hash = "sha256:9f8d36aa52a9926a88b8f1d70cf1fdce0ad387941479b500ee9ab3e51073cefd", size = 90334, upload-time = "2026-06-05T07:34:02.81Z" },
 ]
 
 [[package]]

--- a/docs/docs/advanced/queue-mode-guide.md
+++ b/docs/docs/advanced/queue-mode-guide.md
@@ -237,7 +237,6 @@ Three things to know:
 
 ---
 
-
 ## How It Works in Lambda (Serverless)
 
 ### Components

--- a/docs/docs/advanced/queue-mode-guide.md
+++ b/docs/docs/advanced/queue-mode-guide.md
@@ -37,7 +37,7 @@ The queue transport is pluggable via `execution.queues.type`:
 | `in_memory` | ✅ the default | All five components as threads in one process (local, single-container) |
 | `sqs` | ✅ | Two-process topology on AWS; also the transport behind the Lambda and ECS deployment adapters below |
 | `kafka` | ✅ (`pip install agentkernel[kafka]`) | Kubernetes / on-prem two-process topology |
-| `nats` | Upcoming (#495) | Kubernetes / on-prem two-process topology |
+| `nats` (recommended on-prem) | ✅ (`pip install agentkernel[nats]`) | Kubernetes / on-prem two-process topology |
 
 Delivery sub-modes (`execution.mode`):
 
@@ -179,6 +179,59 @@ dedicated topics for the pipeline, keep retention short (24-72 hours is plenty),
 `group_id` change as a deliberate replay.
 
 ---
+
+## Running Queue Mode on NATS JetStream
+
+The recommended on-prem broker: one static Go binary, an official Helm chart, and NACK CRDs for
+declarative streams. Install the extra (`pip install agentkernel[nats]`) and configure it:
+
+```yaml
+execution:
+  mode: rest_sync
+  queues:
+    type: nats
+    nats:
+      url: "nats://nats:4222"
+      input_stream: AGENT_REQUESTS
+      input_subject_prefix: chat.req
+      output_stream: AGENT_REPLIES
+      output_subject_prefix: chat.out
+      partitions: 32          # sessions hash to a partition; caps concurrent work
+      ack_wait: 300           # visibility timeout: must exceed your longest agent turn
+      retry_backoff: 2.0      # nak delay before a redelivery
+      auto_provision: false   # true for local/dev; leave false where NACK CRs own the objects
+  response_store:             # required: the two processes must share it
+    type: valkey
+    valkey:
+      url: "valkey://valkey:6379"
+```
+
+Process layout is identical to the other broker transports: `IOHandler.run()` in one process,
+`AgentRunner.run()` in the other.
+
+JetStream is the closest fit of any backend here, because the server provides most of what the
+pipeline needs rather than the client rebuilding it: `ack_wait` is the visibility timeout,
+`num_delivered` is an exact delivery count, `max_deliver` enforces the ceiling server-side,
+`Nats-Msg-Id` plus the stream's duplicate window is deduplication, and `term()` is the terminal
+disposition. There is no bookkeeping store and no dead-letter topic to provision.
+
+Three things to know:
+
+- **Partitions set your concurrency**, as on Kafka, but the server enforces it. Sessions hash to a
+  partition subject, each served by a durable consumer with `max_ack_pending: 1`, so a session's
+  turns stay ordered and at most `partitions` messages are in flight cluster-wide. Agent Kernel logs
+  the ratio at startup and warns when partitions are fewer than the configured consumers. Changing
+  the count re-maps sessions, so size it up front.
+- **`ack_wait` must exceed your longest turn.** It defaults to 300 seconds here rather than
+  JetStream's usual 30, because it is a visibility timeout: a turn that outlives it is redelivered
+  and the agent runs again.
+- **`auto_provision` is off by default.** Locally, turn it on and Agent Kernel creates the streams
+  and per-partition consumers at startup. In production, leave it off so a missing stream or consumer
+  fails loudly at startup, naming the object, instead of being silently created with defaults
+  alongside your NACK CRs.
+
+---
+
 
 ## How It Works in Lambda (Serverless)
 
@@ -512,7 +565,7 @@ this automatically. See the [AWS Containerized deployment docs](../deployment/aw
 | `in_memory` | ✅ | The default: single-process pipeline, full semantics minus durability |
 | `sqs` | ✅ | Two-process topology on AWS, wire-compatible with the Lambda/ECS adapters below |
 | `kafka` | ✅ | confluent-kafka client, per-session ordering by record key, DLQ topics, Strimzi-provisioned clusters. Needs the `kafka` extra and an `execution.queues.kafka` block; see the notes below |
-| `nats` (recommended on-prem) | Upcoming | JetStream work-queue streams, partitioned per-session ordering |
+| `nats` (recommended on-prem) | ✅ | JetStream work-queue streams, partitioned per-session ordering, server-side delivery counts and dedup. Needs the `nats` extra and an `execution.queues.nats` block |
 | Kubernetes Helm chart (baremetal + EKS) | Upcoming | Two-Deployment topology, KEDA autoscaling |
 
 **AWS deployment components:**

--- a/docs/docs/advanced/queue-mode-guide.md
+++ b/docs/docs/advanced/queue-mode-guide.md
@@ -209,6 +209,11 @@ execution:
 Process layout is identical to the other broker transports: `IOHandler.run()` in one process,
 `AgentRunner.run()` in the other.
 
+A runnable version, including a single-server JetStream stack and a harness that inspects the
+streams safely (a work-queue stream cannot be browsed with a second consumer, so it reads by
+sequence), is in
+[`examples/transport/nats`](https://github.com/yaalalabs/agent-kernel/tree/develop/examples/transport/nats).
+
 JetStream is the closest fit of any backend here, because the server provides most of what the
 pipeline needs rather than the client rebuilding it: `ack_wait` is the visibility timeout,
 `num_delivered` is an exact delivery count, `max_deliver` enforces the ceiling server-side,

--- a/docs/specs/495-onprem-kubernetes/plan.md
+++ b/docs/specs/495-onprem-kubernetes/plan.md
@@ -128,8 +128,15 @@ Spec section references are to `spec.md`.
   computed client-side with a stable `crc32` (no server-side subject transform, so
   `auto_provision: false` operators need no transform in their NACK CRs), and `ack_wait` defaults
   to 300 s rather than 30 s because it is the visibility timeout and a turn that outlives it is
-  executed twice. A `nats-server` container run and an `examples/transport/nats` sibling to the
-  Kafka example are still outstanding.
+  executed twice.
+- **Also delivered:** `examples/transport/nats/` (two-process pipeline over a single-server
+  JetStream stack) with `nats_tester.py`, which brings up the stack, waits on a real JetStream
+  account lookup, and inspects streams with direct gets rather than a second consumer (a work-queue
+  stream rejects overlapping consumers, and a peeking consumer would steal work). Its `app_test.py`
+  covers rest_sync, a multi-turn session, stream and per-partition consumer provisioning, and the
+  retry-to-termination path. **Not yet run against a real `nats-server`** (no Docker at the time of
+  writing) and, like the Kafka example, not registered in CI: that is iteration 11, and it needs the
+  `nats` extra published.
 
 ## Phase C: WebSocket delivery and Kubernetes
 

--- a/docs/specs/495-onprem-kubernetes/plan.md
+++ b/docs/specs/495-onprem-kubernetes/plan.md
@@ -122,8 +122,14 @@ Spec section references are to `spec.md`.
   `pyproject.toml` (`nats` extra).
 - **Steps:** `_NatsLoop` bridge; partitioned streams/consumers + subject transform;
   `auto_provision` create/verify; ack/nak/term mapping.
-- **Verify:** `test_pipeline_nats_transport.py`; contract suite behind a local `nats-server`
-  container (integration).
+- **Verify:** `test_pipeline_nats_transport.py` (fake JetStream behind the real `_NatsLoop`
+  bridge) plus the `QueueTransportContract` with no skips, since `ack_wait` gives NATS a genuine
+  visibility timeout. Shipped deviations from the §7 sketch, both recorded there: partitioning is
+  computed client-side with a stable `crc32` (no server-side subject transform, so
+  `auto_provision: false` operators need no transform in their NACK CRs), and `ack_wait` defaults
+  to 300 s rather than 30 s because it is the visibility timeout and a turn that outlives it is
+  executed twice. A `nats-server` container run and an `examples/transport/nats` sibling to the
+  Kafka example are still outstanding.
 
 ## Phase C: WebSocket delivery and Kubernetes
 

--- a/docs/specs/495-onprem-kubernetes/plan.md
+++ b/docs/specs/495-onprem-kubernetes/plan.md
@@ -134,9 +134,10 @@ Spec section references are to `spec.md`.
   account lookup, and inspects streams with direct gets rather than a second consumer (a work-queue
   stream rejects overlapping consumers, and a peeking consumer would steal work). Its `app_test.py`
   covers rest_sync, a multi-turn session, stream and per-partition consumer provisioning, and the
-  retry-to-termination path. **Not yet run against a real `nats-server`** (no Docker at the time of
-  writing) and, like the Kafka example, not registered in CI: that is iteration 11, and it needs the
-  `nats` extra published.
+  retry-to-termination path. **Verified against a real single-server JetStream stack**: the
+  `QueueTransportContract` passed 10/10 with no skips (`ack_wait` is a genuine visibility timeout, so
+  the unacked-redelivery case applies here where it does not on Kafka) and the example's own suite
+  passed 4/4 with a live agent, exercising `auto_provision` against the server.
 
 ## Phase C: WebSocket delivery and Kubernetes
 

--- a/docs/specs/495-onprem-kubernetes/spec.md
+++ b/docs/specs/495-onprem-kubernetes/spec.md
@@ -311,23 +311,55 @@ Client `nats-py` (new `nats` extra). Per `research/nats-jetstream.md`:
 
 - **Event-loop bridge**: module-level `_NatsLoop` singleton: one daemon thread running
   `loop.run_forever()`; all client coroutines dispatched via
-  `asyncio.run_coroutine_threadsafe(...).result(timeout)`. One `nats` connection per process.
-- **Subjects/streams**: input `chat.req.<session_id>` on stream `AGENT_REQUESTS` with a
-  deterministic-subject-mapping transform to `chat.req.<partition>.<session_id>` (`partitions`
-  config, default 32); output symmetric on `AGENT_REPLIES` / `chat.out.*` (spec decision for the
-  design's open point: the output path **is** partitioned, same count: per-session chunk order
-  needs it and idle partitions are free). Retention `WorkQueuePolicy`, `duplicate_window` 300 s,
-  `max_age` 24 h safety net.
-- **Send**: `js.publish(subject, body, headers={"Nats-Msg-Id": dedup_id, ...attributes})`.
-- **Consumers**: durable pull consumer per partition (`filter_subject="chat.req.<p>.>"`,
-  `ack_wait` config default 30 s, `max_deliver = max_receive_count + 1`, `max_ack_pending=1`).
-  Each consumer thread cycles the partition consumers in a shuffled order calling
-  `fetch(1, timeout=wait_seconds/partitions)`; the server serializes competing fetchers per
-  partition. Envelope: `receive_count = msg.metadata.num_delivered`, attributes from headers,
-  `group_id` = subject's session token, `native=msg`.
-- **Ack** = `msg.ack()`. **Nack** = `msg.nak(delay=retry_backoff)`. **Permanent failure**: after
-  the hook, `ack` calls `msg.term()` (removes from the work-queue stream; `max_deliver` is the
-  server-side backstop).
+  `asyncio.run_coroutine_threadsafe(...).result(timeout)`, cancelling the coroutine on timeout so a
+  stalled call cannot leak work onto the loop. One `nats` connection per process.
+- **Subjects/streams**: streams `AGENT_REQUESTS` (`chat.req.>`) and `AGENT_REPLIES` (`chat.out.>`),
+  retention `WorkQueuePolicy`, `duplicate_window` 300 s, `max_age` 24 h safety net. The output path
+  **is** partitioned at the same count (spec decision for the design's open point: per-session
+  chunk order needs it and idle partitions are free).
+- **Partitioning is client-side** (implementation decision, deviating from the research note's
+  server-side subject transform): the publisher computes
+  `partition = crc32(session_id) % partitions` and publishes straight to
+  `<prefix>.<partition>.<session_token>`. Rationale: it needs no server-side subject-transform
+  support, keeps `auto_provision: false` operators from having to encode a transform in their NACK
+  CRs, and is deterministic and unit-testable in Python. **`crc32`, not `hash()`**: Python salts
+  string hashing per interpreter, so two pods would disagree about a session's partition and its
+  ordering guarantee would silently disappear. An external producer that publishes unpartitioned
+  subjects would need either the same hash or a server-side transform added by the operator.
+- **Send**: `js.publish(subject, body, headers={"Nats-Msg-Id": dedup_id, "Ak-Group-Id": session,
+  ...attributes})`, awaiting the `PubAck` (so an unreachable server fails the request). The session
+  id travels as a **header** as well as a subject token, because a subject token cannot contain
+  dots while a session id can; the header is authoritative and the token is for routing and
+  observability. A `duplicate` PubAck is logged, not raised: the stream rejecting a repeated dedup
+  id is the requested behaviour.
+- **Dedup scope**: JetStream's duplicate window is per stream, and requests and replies live on
+  different streams, so a reply may safely carry its request's dedup id. (The Kafka transport had
+  to scope its own claim by topic to obtain the same property; §6.)
+- **Consumers**: durable pull consumer per partition, named `<stream>-p<n>`
+  (`filter_subject="<prefix>.<p>.>"`: non-overlapping filters are a hard requirement on a
+  work-queue stream, `ack_wait` config, `max_deliver = max_receive_count + 1`, `max_ack_pending=1`
+  so one message per partition is in flight and a session's turns stay ordered). A consumer holds
+  one pull subscription per partition and a `fetch` walks them from a rotating cursor that starts
+  at a random offset per instance (threads and replicas neither converge on one partition nor
+  starve any), with a per-partition wait of `max(wait_seconds / partitions, 50 ms)` and the whole
+  call bounded by `wait_seconds`. Envelope: `receive_count = msg.metadata.num_delivered` (exact,
+  server-supplied), attributes from headers minus the two AK/NATS headers, `group_id` from
+  `Ak-Group-Id`, `message_id = "<stream>:<stream_seq>"`, `native=msg`.
+- **`ack_wait` defaults to 300 s, not 30** (deviation from the earlier sketch): it is the visibility
+  timeout, so a turn that outlives it is redelivered and the agent runs a second time. 300 s matches
+  the `in_memory` transport's reasoning about LLM-bound turns. `msg.in_progress()` exists as a
+  future refinement for extending the window mid-run.
+- **Ack** = `msg.ack()`. **Nack** = `msg.nak(delay=retry_backoff)`, and unlike Kafka the consumer
+  thread does not sleep out the backoff because the server owns the redelivery. **Permanent
+  failure**: `dead_letter` (§2) calls `msg.term()`, which stops redelivery and removes the message
+  from the work-queue stream while recording intent, with `max_deliver` as the server-side backstop.
+  No dead-letter stream is needed: the component's permanent-failure hook has already delivered the
+  error to the caller.
+- **Capacity check**: `check_consumer_capacity` warns when `partitions < no_of_consumers`, since
+  each partition consumer allows one in-flight message and therefore caps concurrency regardless of
+  how many threads poll.
+- **No bookkeeping store**: unlike Kafka, delivery counts and deduplication are server-side, so
+  `BookkeepingStore` is not involved and NATS needs no shared key store for correctness.
 - **Provisioning**: `auto_provision: true` (default in `values-dev` and local) creates
   streams/consumers/transforms via the JS management API at startup; `false` (production) only
   verifies and raises `AKConfigError` naming the missing object and pointing at the NACK CRs.
@@ -529,7 +561,11 @@ class _NatsQueueConfig(BaseModel):
     input_stream: str = "AGENT_REQUESTS"; input_subject_prefix: str = "chat.req"
     output_stream: str = "AGENT_REPLIES"; output_subject_prefix: str = "chat.out"
     partitions: int = 32
-    ack_wait: float = 30.0; retry_backoff: float = 2.0
+    ack_wait: float = 300.0                # visibility timeout: must exceed the longest turn (§7)
+    retry_backoff: float = 2.0             # nak delay
+    duplicate_window: float = 300.0        # stream dedup window (SQS parity)
+    max_age: float = 86400.0               # safety net: work-queue messages are otherwise kept forever
+    request_timeout: float = 10.0          # bound on any single bridged client call
     auto_provision: bool = False
 
 class _QueuesConfig(BaseModel):             # config.py:356: extended
@@ -762,9 +798,15 @@ New test files (patterns per `ak-dev-testing-conventions`: `DummyAgent`/`DummyRu
   (attempt counts, retry-safe dedup claims incl. owner reclaim, expiry), key prefixes and
   create-only counter TTL on the driver-backed store, and factory selection from the session
   config incl. the once-per-process fallback warning.
-- `test_pipeline_nats_transport.py`: faked `nats` client on a real `_NatsLoop`: subject
-  construction, `Nats-Msg-Id`, `num_delivered` mapping, `term()` on permanent failure,
-  `auto_provision=false` verification error.
+- `test_pipeline_nats_transport.py`: a fake JetStream behind a **real** `_NatsLoop` (so the
+  thread-to-loop bridge is exercised, not mocked): loop identity and timeout-cancellation, subject
+  and header construction, the stable-hash partition mapping (including that it is not Python's
+  salted `hash()`), dot-containing session ids staying one subject token, `num_delivered` mapping,
+  nak redelivery, `term()` on permanent failure, one-in-flight-per-partition, stream-scoped dedup
+  (a reply may reuse its request's id), `auto_provision` create-vs-verify including the named
+  missing object and that a failed attempt is retried rather than cached, the capacity warning, and
+  the full `QueueTransportContract` with **no skips** (`ack_wait` is a real visibility timeout, so
+  the unacked-redelivery case applies here where it does not on Kafka).
 - `test_pipeline_agent_runner.py` / `test_pipeline_response_handler.py`: mirror the assertions
   of `test_akagentrunner_stream.py`/`test_akresponsehandler.py` on the generalized classes,
   including `STATUS_CODE` propagation and the in_memory-STREAM chunk path.

--- a/examples/transport/kafka/build.sh
+++ b/examples/transport/kafka/build.sh
@@ -15,5 +15,5 @@ else
   # published one, so without it uv can satisfy the install from its cache and quietly hand you
   # the release instead of your build.
   uv sync --find-links ../../../ak-py/dist --all-extras
-  uv pip install --force-reinstall --no-deps --no-index --no-cache --find-links ../../../ak-py/dist agentkernel[api,openai,kafka,valkey,test] || true
+  uv pip install --force-reinstall --no-deps --no-index --no-cache --find-links ../../../ak-py/dist agentkernel[api,openai,kafka,valkey,test]
 fi

--- a/examples/transport/nats/README.md
+++ b/examples/transport/nats/README.md
@@ -1,0 +1,142 @@
+# Agent Kernel queue mode over NATS JetStream (OpenAI Agents SDK)
+
+This demo runs Agent Kernel's chat execution pipeline
+
+```
+Request Handler → AGENT_REQUESTS → Agent Runner → AGENT_REPLIES → Response Handler
+```
+
+across **two processes** with a real NATS server between them. It is the same pipeline the
+`examples/api/openai` demo runs in a single process over in-memory queues, with only configuration
+changed: `execution.queues.type: nats` plus a shared response store.
+
+NATS is the recommended on-prem broker: a single static Go binary that idles at tens of megabytes,
+with an official Helm chart and CRDs for declarative streams. `nats_tester.py` starts it, waits for
+JetStream, and gives you commands for looking inside the streams while the pipeline runs.
+
+## Prerequisites
+
+- Docker (for the NATS server and Valkey)
+- `OPENAI_API_KEY` exported
+- `./build.sh` (or `./build.sh local` to install `agentkernel` from `../../../ak-py/dist`)
+
+> The `nats` extra ships with the release that introduces this transport. Until that release is on
+> PyPI, build with `./build.sh local` after `cd ak-py && ./build.sh` has produced a wheel in
+> `ak-py/dist`.
+
+## Quickstart
+
+```bash
+./build.sh
+export OPENAI_API_KEY=sk-...
+
+python nats_tester.py up         # NATS + Valkey, waits until JetStream answers
+python app.py runner             # terminal 2: the Agent Runner
+python app.py io                 # terminal 3: the REST API and Response Handler
+```
+
+Then send a request:
+
+```bash
+curl -X POST http://localhost:8000/api/v1/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "I am Andy Dufresne. I did some deposits.",
+       "session_id": "session-1",
+       "agent": "support"}'
+```
+
+When you are done:
+
+```bash
+python nats_tester.py down        # stops both containers and deletes their state
+```
+
+## What the two processes do
+
+| Process | Entrypoint | Responsibility |
+|---------|-----------|----------------|
+| `python app.py io` | `IOHandler.run()` | Serves `/api/v1/chat`, publishes to `AGENT_REQUESTS`, consumes `AGENT_REPLIES`, writes replies to the response store |
+| `python app.py runner` | `AgentRunner.run()` | Consumes `AGENT_REQUESTS`, runs the agent, publishes the reply to `AGENT_REPLIES` |
+
+Scale the runner by starting more of them (up to the partition count, see below). Note that
+`RESTAPI.run()` is *not* used here: it boots the whole pipeline in one process only when the
+transport resolves to `in_memory`, so on a broker transport the IO side starts explicitly through
+`IOHandler`.
+
+## The tester
+
+```bash
+python nats_tester.py up                     # compose up, wait for JetStream
+python nats_tester.py streams                # message counts and partition consumers per stream
+python nats_tester.py tail AGENT_REQUESTS    # print what a stream is holding
+python nats_tester.py publish --session s1 --data '{"prompt":"hi"}'
+python nats_tester.py provision              # create streams/consumers explicitly (see below)
+python nats_tester.py purge                  # empty the streams, keep their configuration
+python nats_tester.py down                   # stop everything, remove volumes
+```
+
+Two things about inspection are worth understanding, because they differ from Kafka:
+
+- **You cannot browse a work-queue stream with another consumer.** Consumers on a work-queue stream
+  must have non-overlapping filter subjects, so attaching one to peek would either be rejected by
+  the server or steal work from the running pipeline. `tail` therefore reads by sequence with a
+  JetStream *direct get*, which delivers nothing to any consumer.
+- **An acked message is gone.** Work-queue retention removes a message when the pipeline
+  acknowledges it, so a healthy request barely appears in `tail`. Messages you *do* see are usually
+  in flight, retrying, or waiting behind a busy partition. That is the queue working, not a bug.
+
+`publish` builds its subject with the transport's own partition hash, so an injected message lands
+exactly where the pipeline would have put it.
+
+## Provisioning: two postures
+
+This example sets `auto_provision: true`, so Agent Kernel creates the streams and one durable
+consumer per partition at startup. That is the local and dev posture.
+
+Production leaves it `false` and manages the objects declaratively (NACK CRs, or the `nats` CLI), so
+a missing stream or consumer fails loudly at startup, naming what is absent, instead of being
+created with defaults that quietly disagree with your intent. To rehearse that here:
+
+```bash
+python nats_tester.py provision                     # create the objects explicitly
+# set auto_provision: false in config.yaml, then start the pipeline: it verifies instead of creating
+```
+
+Delete a consumer and start again to see the failure message.
+
+## Tests
+
+```bash
+uv run pytest -s
+```
+
+The suite brings the stack up, starts both processes, exercises `rest_sync` including a multi-turn
+session, checks that both streams exist with one consumer per partition, and then feeds the runner
+a message it cannot parse to prove the retry and termination path against a real server: it asserts
+the wire shape while the message lingers through its retries, then that JetStream removes it once
+the pipeline terminates it. It skips itself when Docker or `OPENAI_API_KEY` is missing.
+
+## Things worth knowing about JetStream as a queue
+
+- **It is the closest fit of any backend here.** The server provides the visibility timeout
+  (`ack_wait`), an exact delivery count (`num_delivered`), a server-enforced delivery ceiling
+  (`max_deliver`), deduplication (`Nats-Msg-Id` plus the stream's duplicate window), and a terminal
+  disposition (`term()`). Unlike Kafka, none of that is rebuilt in Agent Kernel, so there is no
+  retry-bookkeeping store and no dead-letter topic to provision.
+- **Partitions set your concurrency, and the server enforces it.** Sessions hash to a partition
+  subject, each served by a durable consumer with `max_ack_pending: 1`, so a session's turns stay
+  ordered and at most `partitions` messages are in flight across the whole cluster. Keep
+  `no_of_consumers × replicas` at or below the partition count; the runner logs the ratio at startup
+  and warns when it is short. Changing the count re-maps sessions, so size it up front (32 is the
+  production default; this example uses 4 to keep provisioning quick).
+- **`ack_wait` must exceed your longest turn.** It defaults to 300 seconds here rather than
+  JetStream's usual 30, because it is a visibility timeout: a turn that outlives it is redelivered
+  and the agent runs a second time.
+- **Permanent failure terminates rather than dead-letters.** After the pipeline's permanent-failure
+  hook has delivered the error to the caller, the message is `term()`ed, which stops redelivery and
+  removes it from the work-queue stream. `max_deliver` is the server-side backstop behind that.
+
+This stack is deliberately not production shaped: one server, no clustering, ephemeral storage. A
+real deployment runs a 3-node cluster with streams and consumers at `replicas: 3`, from the official
+`nats` Helm chart. See the
+[Queue Mode Guide](https://kernel.yaala.ai/docs/advanced/queue-mode-guide) for the full picture.

--- a/examples/transport/nats/app.py
+++ b/examples/transport/nats/app.py
@@ -1,0 +1,63 @@
+"""Agent Kernel queue mode over NATS JetStream: the two-process pipeline.
+
+JetStream is a broker transport, so the pipeline is split across two processes that share the
+streams and the response store:
+
+    python app.py io        # Request Handler (REST API) + Response Handler
+    python app.py runner    # Agent Runner
+
+Both read the same config.yaml. Start the infrastructure first with ``python nats_tester.py up``.
+"""
+
+import sys
+
+from agentkernel.openai import OpenAIModule, OpenAIToolBuilder
+from agentkernel.pipeline import AgentRunner, IOHandler
+from agents import Agent
+
+from tool import fetch_customer_activity
+
+general_agent = Agent(
+    name="general",
+    handoff_description="Agent for general questions",
+    instructions="You provide assistance with general queries. Give short and direct answers.",
+)
+
+customer_support_agent = Agent(
+    name="support",
+    instructions="You are a customer feedback agent. When I give you the name of the customer you will generate "
+    "the feedback conversation. I will also tell the banking operation this customer carried out. "
+    "You will only ask questions on satisfaction based on only the activities the user carried out. "
+    "When I provide the name and the work, you will assume you are having a conversation with this "
+    "customer itself and mimic the conversation. Ask questions one by one and gather answers and show "
+    "the summary once the conversation is over.",
+    # Agent Kernel's builder turns plain functions into this framework's tool objects, which is
+    # what keeps tool.py free of any framework import.
+    tools=OpenAIToolBuilder.bind([fetch_customer_activity]),
+)
+
+triage_agent = Agent(
+    name="triage",
+    instructions="You determine which agent to use based on the user's question.",
+    handoffs=[general_agent, customer_support_agent],
+)
+
+OpenAIModule([triage_agent, general_agent, customer_support_agent])
+
+# The two process entrypoints. RESTAPI.run() is deliberately not used here: it only boots the
+# whole pipeline in-process when the transport resolves to in_memory, so on a broker transport the
+# IO side is started explicitly through IOHandler.
+ENTRYPOINTS = {"io": IOHandler.run, "runner": AgentRunner.run}
+
+
+def main(argv: list[str]) -> int:
+    role = argv[1] if len(argv) > 1 else ""
+    if role not in ENTRYPOINTS:
+        print(f"usage: python app.py [{' | '.join(ENTRYPOINTS)}]", file=sys.stderr)
+        return 2
+    ENTRYPOINTS[role]()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/examples/transport/nats/app_test.py
+++ b/examples/transport/nats/app_test.py
@@ -1,0 +1,173 @@
+"""End-to-end test of the NATS JetStream queue-mode pipeline against a real server.
+
+The stack (nats-server with JetStream, Valkey) comes from :mod:`nats_tester`; the two pipeline
+processes are started the same way you would start them by hand. Beyond the happy path, the last
+test feeds the runner a message it cannot parse to prove the retry and termination semantics hold
+on a real server: JetStream counts the deliveries, and the message is removed from the work-queue
+stream once the pipeline gives up on it.
+
+Skipped when Docker or an OpenAI key is unavailable.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+
+import httpx
+import pytest
+from agentkernel.test import Test
+
+from nats_tester import INPUT_STREAM, OUTPUT_STREAM, NatsTester
+
+API_URL = "http://localhost:8000"
+# max_receive_count (2) plus retry_backoff (1 s) from config.yaml, with room for the runner to
+# notice and for the error reply to reach the output stream.
+TERMINATION_WAIT_SECONDS = 45
+
+
+class APITestClient:
+    def __init__(self, url):
+        self.url = url
+        self.session_id = str(uuid.uuid4())
+
+    async def send(self, prompt):
+        payload = {"prompt": prompt, "session_id": self.session_id, "agent": "support"}
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(f"{self.url}/api/v1/chat", json=payload)
+            resp.raise_for_status()
+            return resp.json().get("result", "")
+
+
+def _start(role: str) -> subprocess.Popen:
+    return subprocess.Popen([sys.executable, "app.py", role], stdout=sys.stdout, stderr=sys.stderr)
+
+
+def _wait_for_api(timeout: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if httpx.get(f"{API_URL}/health", timeout=2.0).status_code == 200:
+                return
+        except httpx.HTTPError:
+            time.sleep(1)
+    raise TimeoutError("the pipeline's REST API never became healthy")
+
+
+@pytest.fixture(scope="session")
+def nats_stack():
+    """The NATS server and Valkey. Streams are created by the pipeline itself, since the example
+    runs with auto_provision: true."""
+    if shutil.which("docker") is None:
+        pytest.skip("Docker is not installed or not in PATH")
+    if not os.environ.get("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY is not set; skipping integration test")
+
+    tester = NatsTester()
+    tester.up()
+    try:
+        yield tester
+    finally:
+        tester.down()
+
+
+@pytest.fixture(scope="session")
+def pipeline(nats_stack):
+    """Both pipeline processes: the runner consuming the request stream, the IO side serving REST."""
+    runner = _start("runner")
+    io_process = _start("io")
+    try:
+        _wait_for_api()
+        yield nats_stack
+    finally:
+        for process in (io_process, runner):
+            process.terminate()
+            try:
+                process.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=10)
+
+
+@pytest.fixture
+def client(pipeline):
+    return APITestClient(API_URL)
+
+
+@pytest.mark.asyncio
+async def test_support_agent_over_nats(client):
+    """A rest_sync request: published to a partition subject on AGENT_REQUESTS, answered from
+    AGENT_REPLIES via Valkey."""
+    response = await client.send("I am Andy Dufresne. I did some deposits.")
+    Test.compare(
+        response,
+        [
+            "Hello Andy! I noticed that you made a mobile check deposit of $250. Could you tell me how satisfied "
+            "you were with the mobile check deposit process?"
+        ],
+        threshold=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_continues_across_turns(client):
+    """A session's turns hash to one partition subject, so they stay ordered behind each other."""
+    await client.send("I am Andy Dufresne. I did some deposits.")
+    response = await client.send("I was extremely happy")
+    Test.compare(
+        response,
+        ["That's great to hear! What did you like most about the mobile check deposit process?"],
+        threshold=10,
+    )
+
+
+def test_streams_and_partition_consumers_exist(pipeline):
+    """auto_provision created both work-queue streams with one durable consumer per partition."""
+    described = pipeline.describe()
+
+    for stream in (INPUT_STREAM, OUTPUT_STREAM):
+        assert described[stream]["exists"], f"{stream} was not provisioned"
+        # partitions: 4 in config.yaml
+        assert described[stream]["consumers"] == 4, f"{stream} should have one consumer per partition"
+
+
+def test_unprocessable_message_is_terminated(pipeline):
+    """The retry contract on a real server, and the only message guaranteed to sit still long
+    enough to inspect: a work-queue stream drops anything the pipeline acks, so a healthy request
+    is gone almost immediately, while a message the runner cannot parse lingers through its
+    retries. This asserts the wire shape while it lingers, then that JetStream removes it once the
+    pipeline terminates it (which is what stops it blocking its partition).
+    """
+    poison_session = f"poison-{uuid.uuid4().hex[:8]}"
+    request_id = str(uuid.uuid4())
+    subject = pipeline.publish(
+        session=poison_session,
+        data=json.dumps({"not_a": "run request"}),
+        headers={"request_id": request_id},
+    )
+
+    tokens = subject.split(".")  # chat.req.<partition>.<session>
+    assert len(tokens) == 4, f"expected a partitioned subject, got {subject}"
+    assert tokens[2].isdigit() and int(tokens[2]) < 4, "the session hashed to one of the configured partitions"
+    assert tokens[3] == poison_session, "the session id is a single subject token"
+
+    def held():
+        return [
+            message
+            for message in pipeline.tail(INPUT_STREAM)
+            if message["headers"].get("Ak-Group-Id") == poison_session
+        ]
+
+    in_stream = held()
+    assert in_stream, "the injected message should be waiting in the request stream"
+    assert in_stream[0]["headers"]["request_id"] == request_id, "routing metadata travels as headers"
+    assert in_stream[0]["subject"] == subject
+
+    deadline = time.monotonic() + TERMINATION_WAIT_SECONDS
+    while time.monotonic() < deadline and held():
+        time.sleep(1)
+
+    assert not held(), f"the poison message was not terminated within {TERMINATION_WAIT_SECONDS} s"

--- a/examples/transport/nats/build.sh
+++ b/examples/transport/nats/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+if command -v pyenv >/dev/null 2>&1; then
+  uv venv --python "$(pyenv which python)" --allow-existing
+else
+  uv venv --allow-existing
+fi
+
+if [[ ${1-} != "local" ]]; then
+  uv sync --all-extras
+else
+  # For local development of agentkernel, you can force reinstall from local dist.
+  # --no-cache matters here: a locally built wheel usually carries the same version as the
+  # published one, so without it uv can satisfy the install from its cache and quietly hand you
+  # the release instead of your build.
+  uv sync --find-links ../../../ak-py/dist --all-extras
+  uv pip install --force-reinstall --no-deps --no-index --no-cache --find-links ../../../ak-py/dist agentkernel[api,openai,nats,valkey,test] || true
+fi

--- a/examples/transport/nats/build.sh
+++ b/examples/transport/nats/build.sh
@@ -15,5 +15,5 @@ else
   # published one, so without it uv can satisfy the install from its cache and quietly hand you
   # the release instead of your build.
   uv sync --find-links ../../../ak-py/dist --all-extras
-  uv pip install --force-reinstall --no-deps --no-index --no-cache --find-links ../../../ak-py/dist agentkernel[api,openai,nats,valkey,test] || true
+  uv pip install --force-reinstall --no-deps --no-index --no-cache --find-links ../../../ak-py/dist agentkernel[api,openai,nats,valkey,test]
 fi

--- a/examples/transport/nats/config.yaml
+++ b/examples/transport/nats/config.yaml
@@ -1,0 +1,52 @@
+# Agent Kernel queue mode over NATS JetStream (two-process pipeline).
+#
+# Start the server and Valkey with `python nats_tester.py up`. Unlike the Kafka example, the
+# streams and consumers do not have to exist beforehand: auto_provision below lets Agent Kernel
+# create them at startup, which is the local and dev posture. Production leaves it false and
+# manages the objects declaratively (NACK CRs), so a missing stream fails loudly instead of being
+# created with defaults.
+
+execution:
+  mode: rest_sync              # rest_sync (wait for the reply) | rest_async (accept, then poll)
+
+  queues:
+    type: nats
+
+    nats:
+      url: "nats://localhost:4222"
+      input_stream: AGENT_REQUESTS
+      input_subject_prefix: chat.req
+      output_stream: AGENT_REPLIES
+      output_subject_prefix: chat.out
+      partitions: 4              # 32 in production; 4 keeps this demo's provisioning quick
+      ack_wait: 300              # visibility timeout: must exceed your longest agent turn
+      retry_backoff: 1.0         # nak delay before a redelivery (2.0 in production)
+      duplicate_window: 300      # repeated dedup ids are dropped by the stream within this window
+      auto_provision: true       # create the streams and partition consumers if missing
+
+    input:
+      max_receive_count: 2       # deliveries before a message is permanently failed (3 in production)
+      no_of_consumers: 2         # agent-runner threads; keep <= partitions
+    output:
+      no_of_consumers: 1
+
+  # Required on every broker transport: the two processes exchange responses through this store.
+  response_store:
+    type: valkey
+    valkey:
+      url: "valkey://localhost:6379"
+      prefix: "ak:responses:"
+    retry_count: 60              # with delay: how long a rest_sync caller waits (60 x 1s)
+    delay: 1
+
+# JetStream tracks delivery counts and deduplication itself, so unlike Kafka this transport needs
+# no shared key store for retry bookkeeping. Valkey is here only for sessions and responses.
+session:
+  type: valkey
+  valkey:
+    url: "valkey://localhost:6379"
+    prefix: "ak:sessions:"
+
+logging:
+  ak:
+    level: INFO

--- a/examples/transport/nats/docker-compose.yaml
+++ b/examples/transport/nats/docker-compose.yaml
@@ -1,0 +1,35 @@
+# Lightweight local stack for the NATS queue-mode example: one nats-server with JetStream enabled
+# and one Valkey for the response store and sessions. The NATS server is a single static Go binary
+# that idles at tens of megabytes, so this stack is far lighter than the Kafka equivalent.
+#
+# Not a production topology. A real deployment runs a 3-node cluster with streams and consumers at
+# replicas: 3, installed from the official nats Helm chart and managed with NACK CRs.
+
+services:
+  nats:
+    image: nats:2.14-alpine
+    container_name: ak-nats
+    # -js enables JetStream; -m 8222 exposes the monitoring endpoints (/healthz, /jsz) that the
+    # tester and any Prometheus exporter read.
+    command: ["-js", "-sd", "/data", "-m", "8222"]
+    ports:
+      - "4222:4222"   # client connections
+      - "8222:8222"   # monitoring
+    healthcheck:
+      # Informational only: `nats_tester.py up` waits on a real JetStream connection instead, which
+      # is the readiness that actually matters to the pipeline.
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:8222/healthz || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: ak-valkey
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10

--- a/examples/transport/nats/nats_tester.py
+++ b/examples/transport/nats/nats_tester.py
@@ -58,6 +58,7 @@ class NatsTester:
     def __init__(self, url: str = URL):
         self.url = url
         self._request_timeout = 10.0
+        self._client: Optional[Any] = None
 
     # -- infrastructure ------------------------------------------------------------------
 
@@ -71,6 +72,7 @@ class NatsTester:
 
     def down(self) -> None:
         """Stop the stack and delete its volumes: nothing survives to confuse the next run."""
+        self.close()  # release the connection before the server it points at disappears
         self.compose("down", "-v")
 
     def wait_for_jetstream(self, timeout: float = 90.0) -> None:
@@ -188,10 +190,25 @@ class NatsTester:
     # -- internals -----------------------------------------------------------------------
 
     def _jetstream(self) -> Any:
+        """One connection for the life of the tester, reconnecting only when it has dropped.
+
+        Reconnecting per call would leak a socket and its background tasks on every one: the
+        readiness loop alone can call this dozens of times, and `tail` calls it once per invocation.
+        """
         import nats
 
-        client = _NatsLoop.run(nats.connect(servers=[self.url]), self._request_timeout)
-        return client.jetstream()
+        if self._client is None or not self._client.is_connected:
+            self._client = _NatsLoop.run(nats.connect(servers=[self.url]), self._request_timeout)
+        return self._client.jetstream()
+
+    def close(self) -> None:
+        """Drop the connection. Safe to call more than once."""
+        if self._client is not None:
+            try:
+                _NatsLoop.run(self._client.close(), self._request_timeout)
+            except Exception:
+                pass  # the server may already be gone, e.g. straight after `down`
+            self._client = None
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/examples/transport/nats/nats_tester.py
+++ b/examples/transport/nats/nats_tester.py
@@ -1,0 +1,254 @@
+"""A lightweight NATS JetStream harness for this example: bring up a server, look inside the
+streams, and inject messages.
+
+The inspection commands exist because a work-queue stream cannot be browsed the way a Kafka topic
+can. Consumers on a work-queue stream must have non-overlapping filter subjects, so attaching
+another consumer to peek would either be rejected by the server or steal work from the running
+pipeline. Everything here reads by sequence with a JetStream direct get instead, which delivers
+nothing and disturbs no consumer.
+
+Command line:
+
+    python nats_tester.py up                     # compose up, wait for JetStream to answer
+    python nats_tester.py streams                # streams, message counts, and their consumers
+    python nats_tester.py tail AGENT_REPLIES     # print the messages a stream is holding
+    python nats_tester.py publish --session s1 --data '{"prompt":"hi"}'
+    python nats_tester.py provision              # create the streams/consumers explicitly
+    python nats_tester.py purge                  # empty the streams, keeping their configuration
+    python nats_tester.py down                   # compose down, removing all state
+
+It is also importable: ``app_test.py`` uses :class:`NatsTester` to run the same steps.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agentkernel.pipeline.envelope import QueueName
+from agentkernel.pipeline.transport.nats import _NatsLoop
+
+from nats.js.errors import NotFoundError
+
+URL = "nats://localhost:4222"
+INPUT_STREAM = "AGENT_REQUESTS"
+OUTPUT_STREAM = "AGENT_REPLIES"
+STREAMS = [INPUT_STREAM, OUTPUT_STREAM]
+
+COMPOSE_FILE = Path(__file__).parent / "docker-compose.yaml"
+
+
+def _transport():
+    """The transport the example itself is configured with.
+
+    Built from config.yaml through the normal factory, so the tester partitions subjects with
+    exactly the same hash the pipeline uses and cannot drift from it.
+    """
+    from agentkernel.pipeline.transport.base import QueueTransportFactory
+
+    return QueueTransportFactory.create()
+
+
+class NatsTester:
+    """Owns the local server's lifecycle and the inspection commands."""
+
+    def __init__(self, url: str = URL):
+        self.url = url
+        self._request_timeout = 10.0
+
+    # -- infrastructure ------------------------------------------------------------------
+
+    def compose(self, *args: str) -> None:
+        subprocess.run(["docker", "compose", "-f", str(COMPOSE_FILE), *args], check=True)
+
+    def up(self) -> None:
+        """Start the stack and wait until JetStream answers."""
+        self.compose("up", "-d")
+        self.wait_for_jetstream()
+
+    def down(self) -> None:
+        """Stop the stack and delete its volumes: nothing survives to confuse the next run."""
+        self.compose("down", "-v")
+
+    def wait_for_jetstream(self, timeout: float = 90.0) -> None:
+        """Block until JetStream is enabled and reachable.
+
+        Waits on an actual JetStream account lookup rather than a TCP port or the container's
+        health status, because the server accepts connections slightly before JetStream is ready.
+        """
+        deadline = time.monotonic() + timeout
+        last_error: Optional[Exception] = None
+        while time.monotonic() < deadline:
+            try:
+                _NatsLoop.run(self._jetstream().account_info(), self._request_timeout)
+                return
+            except Exception as e:
+                last_error = e
+                time.sleep(1)
+        raise TimeoutError(f"JetStream at {self.url} was not ready within {timeout} s: {last_error}")
+
+    # -- streams -------------------------------------------------------------------------
+
+    def provision(self) -> None:
+        """Create the streams and partition consumers explicitly.
+
+        The example runs with ``auto_provision: true``, so this is not needed for the happy path.
+        It is here to rehearse the production posture: provision with this, set
+        ``auto_provision: false`` in config.yaml, and the pipeline will verify the objects at
+        startup instead of creating them (and fail loudly, naming the object, if any are missing).
+        """
+        transport = _transport()
+        for queue in (QueueName.INPUT, QueueName.OUTPUT):
+            transport._auto_provision = True
+            transport._ensure_provisioned(queue)
+        print(f"provisioned {', '.join(STREAMS)}")
+
+    def describe(self) -> Dict[str, Dict[str, Any]]:
+        """Message counts and consumer names per stream."""
+        jetstream = self._jetstream()
+        described: Dict[str, Dict[str, Any]] = {}
+        for name in STREAMS:
+            try:
+                info = _NatsLoop.run(jetstream.stream_info(name), self._request_timeout)
+            except NotFoundError:
+                described[name] = {"exists": False}
+                continue
+            consumers = _NatsLoop.run(jetstream.consumers_info(name), self._request_timeout)
+            described[name] = {
+                "exists": True,
+                "messages": info.state.messages,
+                "first_seq": info.state.first_seq,
+                "last_seq": info.state.last_seq,
+                "consumers": len(consumers),
+                "pending_per_consumer": {consumer.name: consumer.num_pending for consumer in consumers},
+            }
+        return described
+
+    def purge(self) -> None:
+        """Empty the streams but keep their configuration and consumers."""
+        for name in STREAMS:
+            try:
+                _NatsLoop.run(self._jetstream().purge_stream(name), self._request_timeout)
+                print(f"purged {name}")
+            except NotFoundError:
+                pass
+
+    # -- messages ------------------------------------------------------------------------
+
+    def tail(self, stream: str, limit: int = 50) -> List[dict]:
+        """Read what a stream is holding, by sequence, without consuming anything.
+
+        A direct get delivers nothing to any consumer, which is the only safe way to look inside a
+        work-queue stream while the pipeline is running.
+        """
+        jetstream = self._jetstream()
+        try:
+            info = _NatsLoop.run(jetstream.stream_info(stream), self._request_timeout)
+        except NotFoundError:
+            return []
+
+        messages: List[dict] = []
+        sequence = info.state.first_seq
+        while sequence <= info.state.last_seq and len(messages) < limit:
+            try:
+                raw = _NatsLoop.run(jetstream.get_msg(stream, seq=sequence), self._request_timeout)
+                messages.append(
+                    {
+                        "seq": sequence,
+                        "subject": raw.subject,
+                        "headers": dict(raw.headers or {}),
+                        "data": raw.data.decode() if raw.data else None,
+                    }
+                )
+            except Exception:
+                pass  # a gap: the message was acked and removed, which is normal on a work queue
+            sequence += 1
+        return messages
+
+    def publish(
+        self, session: str, data: str, headers: Optional[Dict[str, str]] = None, queue: QueueName = QueueName.INPUT
+    ) -> str:
+        """Publish a raw message onto a queue's partition subject.
+
+        Uses the transport's own subject builder, so a message injected here lands exactly where
+        the pipeline would have put it. This is how to feed the runner something it cannot process.
+        """
+        transport = _transport()
+        subject = transport.subject_for(queue, session)
+        combined = {"Ak-Group-Id": session, **(headers or {})}
+        _NatsLoop.run(
+            self._jetstream().publish(subject, data.encode(), headers=combined),
+            self._request_timeout,
+        )
+        return subject
+
+    # -- internals -----------------------------------------------------------------------
+
+    def _jetstream(self) -> Any:
+        import nats
+
+        client = _NatsLoop.run(nats.connect(servers=[self.url]), self._request_timeout)
+        return client.jetstream()
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("command", choices=["up", "down", "streams", "tail", "publish", "provision", "purge"])
+    parser.add_argument("stream", nargs="?", help="stream name, for tail")
+    parser.add_argument("--session", default="tester-session", help="session id (decides the partition subject)")
+    parser.add_argument("--data", default="{}", help="message body to publish")
+    parser.add_argument("--limit", type=int, default=50, help="messages to print when tailing")
+    args = parser.parse_args(argv)
+
+    tester = NatsTester()
+
+    if args.command == "up":
+        tester.up()
+        print(f"\nNATS on {URL} (monitoring on http://localhost:8222), Valkey on localhost:6379. Next:\n")
+        print("  python app.py runner      # in one terminal")
+        print("  python app.py io          # in another")
+        return 0
+
+    if args.command == "down":
+        tester.down()
+        return 0
+
+    if args.command == "provision":
+        tester.provision()
+        return 0
+
+    if args.command == "purge":
+        tester.purge()
+        return 0
+
+    if args.command == "streams":
+        for name, details in tester.describe().items():
+            if not details["exists"]:
+                print(f"{name}: missing (start the pipeline with auto_provision, or run `provision`)")
+            else:
+                print(
+                    f"{name}: {details['messages']} message(s) held, {details['consumers']} partition consumer(s), "
+                    f"seq {details['first_seq']}..{details['last_seq']}"
+                )
+        return 0
+
+    if args.command == "tail":
+        if not args.stream:
+            parser.error("tail needs a stream name")
+        held = tester.tail(args.stream, limit=args.limit)
+        if not held:
+            print(f"no messages held in {args.stream}")
+        for message in held:
+            print(json.dumps(message, indent=2))
+        return 0
+
+    subject = tester.publish(args.session, args.data)
+    print(f"published 1 message to {subject}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/transport/nats/pyproject.toml
+++ b/examples/transport/nats/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "transport-nats"
+version = "0.1.0"
+description = "Demo of OpenAI Agents SDK based agents running in Agent Kernel queue mode over NATS JetStream"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "agentkernel[openai,api,nats,valkey]>=0.8.1",
+]
+
+[dependency-groups]
+dev = [
+    "agentkernel[test]>=0.8.1",
+    "black==26.5.1",
+    "isort>=5.0.0",
+    "mypy>=1.0.0",
+]
+
+[tool.uv]
+package = false
+
+[tool.isort]
+profile = "black"
+line_length = 120
+
+[tool.mypy]
+python_version = "3.12"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+[tool.black]
+line-length = 120
+target-version = ["py312"]

--- a/examples/transport/nats/test-config.yaml
+++ b/examples/transport/nats/test-config.yaml
@@ -1,0 +1,8 @@
+# Agent Kernel test harness configuration (loaded only when running tests).
+# See https://kernel.yaala.ai/docs/testing/overview for details.
+mode: fallback  # Test comparison mode: fuzzy, judge, or fallback (default: fallback)
+# Judge settings are used by the judge and fallback modes (LLM-based evaluation):
+judge:
+  model: gpt-4o-mini
+  provider: openai
+  embedding_model: text-embedding-3-small

--- a/examples/transport/nats/tool.py
+++ b/examples/transport/nats/tool.py
@@ -1,0 +1,38 @@
+"""Tools are plain Python functions here: Agent Kernel's ToolBuilder binds them to whichever
+framework the agent uses (see app.py), so the same function would work unchanged under CrewAI,
+LangGraph, ADK, and the rest."""
+
+from typing import Dict, List
+
+
+def fetch_customer_activity(name: str, operations: List[str] | None = None) -> Dict[str, object]:
+    """
+    Returns recent banking activities for a given customer name.
+
+    Use this tool to ground your conversation with the customer by referencing
+    the exact operations they recently performed. If "operations" are provided,
+    the tool will filter to those operation types
+
+    :param name: The full name of the customer.
+    :param operations: Optional list of operation types to include, e.g.,
+        ["deposit", "withdrawal", "transfer", "bill_payment"].
+    :return: A JSON object containing the customer's name and a list of activity
+        records. Each record contains: type, amount, currency, and a short note.
+    """
+    sample: List[Dict[str, object]] = [
+        {"type": "deposit", "amount": 250.00, "currency": "USD", "note": "Deposited over the counter"},
+        {"type": "bill_payment", "amount": 89.99, "currency": "USD", "note": "Utility bill"},
+        {"type": "transfer", "amount": 150.00, "currency": "USD", "note": "To Savings"},
+        {"type": "withdrawal", "amount": 60.00, "currency": "USD", "note": "ATM cash"},
+    ]
+
+    if operations:
+        ops_lower = {op.lower() for op in operations}
+        filtered = [item for item in sample if str(item.get("type", "")).lower() in ops_lower]
+    else:
+        filtered = sample[:3]
+
+    return {
+        "customer": name,
+        "activities": filtered,
+    }


### PR DESCRIPTION
## Description

Iteration 8 of #495: the NATS JetStream queue transport, plus a runnable example with a local
harness. This completes the transport matrix, so all four built-ins now ship: `in_memory`, `sqs`,
`kafka`, `nats`.

Follows #630 (SQS and Kafka transports, public queue interface cleanup) and #621 (the pipeline
itself). Spec §7 and §11 in `docs/specs/495-onprem-kubernetes/` were updated in place to match what
shipped, including three deviations from the original sketch that are called out below.

JetStream is the closest fit of any backend here, because the server provides what the other
brokers make the client rebuild: `ack_wait` is the visibility timeout, `num_delivered` is an exact
delivery count, `max_deliver` enforces the ceiling server-side, `Nats-Msg-Id` plus the stream's
duplicate window is deduplication, and `term()` is the terminal disposition. Consequently this
transport needs **no bookkeeping store and no dead-letter topic**, unlike Kafka.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update
- [ ] CI/CD update
- [ ] Other (please describe):

## Related Issues

Relates to #495

## Changes Made

**Transport** (`pipeline/transport/nats.py`, `nats` extra, `_NatsQueueConfig`)

- **Event-loop bridge.** `nats-py` is asyncio-only and the pipeline's consumers are threads, so
  `_NatsLoop` runs one event loop on a daemon thread and every client coroutine is dispatched with
  `run_coroutine_threadsafe`, cancelling on timeout so a stalled call cannot leak work onto the loop.
  One connection multiplexes every thread in the process.
- **Per-session ordering** is JetStream's one gap (no equivalent of an SQS message group). Sessions
  hash to partition subjects, each served by a durable consumer with `max_ack_pending=1`, so one
  message per partition is in flight and ordered while partitions run in parallel. Same shape as the
  Kafka transport, except the server enforces it instead of the client buffering to achieve it.
- **Provisioning**: `auto_provision: true` creates the work-queue streams and per-partition
  consumers at startup (local and dev); `false` verifies them and raises `AKConfigError` naming the
  missing object and pointing at NACK CRs (production). A failed attempt is not cached, so the next
  call retries rather than skipping.
- **`check_consumer_capacity`** warns when partitions are fewer than the configured consumers, since
  each partition consumer allows one in-flight message and therefore caps concurrency however many
  threads poll.
- `dead_letter` (the seam added in #630) maps to `msg.term()`, which stops redelivery and removes the
  message from the work-queue stream while recording intent, with `max_deliver` as the server-side
  backstop. No dead-letter stream is needed: the permanent-failure hook has already answered the
  caller.

**Three deviations from the §7 sketch, all recorded in the spec**

1. **Partitioning is client-side** (`crc32(session) % partitions`) rather than a server-side subject
   transform: no dependency on server transform support, nothing for `auto_provision: false`
   operators to encode in their NACK CRs, and deterministic enough to unit-test. It uses `crc32` and
   **not Python's `hash()`**, because string hashing is salted per interpreter, so two pods would
   disagree about a session's partition and the ordering guarantee would silently disappear. There is
   a test asserting the literal `crc32` value.
2. **`ack_wait` defaults to 300 s, not 30.** It is the visibility timeout: a turn that outlives it is
   redelivered and the agent runs a second time. This matches the `in_memory` transport's reasoning
   about LLM-bound turns.
3. **The session id travels as a header** (`Ak-Group-Id`) as well as a subject token, because a
   subject token cannot contain dots while a session id can. The header is authoritative; the token
   is for routing and observability.

**Example** (`examples/transport/nats/`)

The two-process pipeline over a single-server JetStream stack, plus `nats_tester.py`
(`up`/`down`/`streams`/`tail`/`publish`/`provision`/`purge`). Two things differ from the Kafka
example by necessity:

- **A work-queue stream cannot be browsed with another consumer.** Consumers must have
  non-overlapping filter subjects, so a peeking consumer would either be rejected by the server or
  steal work from the running pipeline. `tail` reads by sequence with a JetStream **direct get**,
  which delivers nothing to any consumer.
- **An acked message is gone**, since work-queue retention removes it, so a healthy request barely
  appears in `tail`. What you see is usually in flight, retrying, or queued behind a busy partition.

`publish` builds its subject with the transport's own partition hash, so an injected message lands
exactly where the pipeline would have put it and the harness cannot drift from the shipped hashing.

**Factory tidy-up**: with every built-in now implemented, the "not available yet" branch became a
guard for the next transport author, and an unknown non-dotted type now lists the valid options
instead of complaining that it is not a dotted path.

## Testing

- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [x] Manual testing completed
- [x] New tests added for changes

In-repo: **1426 passed, 1 skipped**, with only the three pre-existing `cli_tester` LLM-judge
failures that need a live key. `make lint-check-all` clean.

`test_pipeline_nats_transport.py` (35 tests) puts a fake JetStream behind a **real** `_NatsLoop`, so
the thread-to-loop bridge is exercised rather than mocked: loop identity and timeout cancellation,
subject and header construction, the stable-hash partition mapping, dot-containing session ids
staying one subject token, `num_delivered` mapping, nak redelivery, `term()`, one-in-flight-per-
partition, stream-scoped dedup, `auto_provision` create-vs-verify, and the capacity warning.

**Against a real single-server JetStream stack:**

- `QueueTransportContract`: **10 passed, 0 skipped** in 26 s, and the process exits cleanly. Nothing
  is skipped here where Kafka had to opt out of timeout redelivery, because `ack_wait` is a genuine
  visibility timeout; the unacked-redelivery case passes against the live server.
- The example's own suite with a real agent: **4 passed** in 30 s, covering `rest_sync`, a multi-turn
  session, stream and per-partition consumer provisioning, and the retry-to-termination path (the
  injected message is found with its expected partitioned subject and headers, then removed once the
  pipeline terminates it).
- `auto_provision` was exercised against the live server: each contract test created streams with 8
  partition consumers and deleted them in teardown.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

**One stale line to fix before merge.** `docs/specs/495-onprem-kubernetes/plan.md` (iteration 8,
around line 137) still says the example was "Not yet run against a real `nats-server`". That was
true when the commit was written and is no longer: the contract and the example suite have both since
run against a live server, with the results above. The sentence should be replaced with the live-run
outcome so the plan is not merged as a false record.

**The `nats` extra is not on PyPI yet**, which is the unchecked box above. Until the release that
publishes it, the example builds only with `./build.sh local` against a locally built wheel. For the
same reason the example is **not** registered in `.github/test-config.yaml`; wiring the broker
transports into CI is iteration 11 in the plan.

`examples/transport/nats/uv.lock` is intentionally absent, as with the Kafka example: a local build
generates one pinned to `../../../ak-py/dist`, which must not be committed. Worth knowing that a
stale lock is what silently dropped the `nats` extra during development (uv froze a resolution made
before the local wheel declared it), so deleting the lock is the first thing to try if an extra
appears to be missing after a local build.

Reviewer attention is most valuable on the event-loop bridge (it is the one piece with no analogue in
the other transports) and on the three deviations listed above, particularly the stable-hash
requirement.

Next: iteration 9, pod-direct WebSocket delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
