### PR TITLE
feat: handle missing SSM command invocations with retries and timeouts

### DIFF
--- a/ak-py/src/agentkernel/sandbox/providers/ec2_ssm.py
+++ b/ak-py/src/agentkernel/sandbox/providers/ec2_ssm.py
@@ -123,7 +123,7 @@ class EC2SSMEnvironment(AttachedEnvironment):
         while True:
             try:
                 invocation = await asyncio.to_thread(self._ssm.get_command_invocation, CommandId=command_id, InstanceId=self.id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001 — boto3 may surface missing invocations as different exception types; we inspect the error code below
                 if not _is_missing_invocation(exc):
                     raise
                 await asyncio.sleep(_POLL_INTERVAL)

--- a/ak-py/src/agentkernel/sandbox/providers/ec2_ssm.py
+++ b/ak-py/src/agentkernel/sandbox/providers/ec2_ssm.py
@@ -123,7 +123,7 @@ class EC2SSMEnvironment(AttachedEnvironment):
         while True:
             try:
                 invocation = await asyncio.to_thread(self._ssm.get_command_invocation, CommandId=command_id, InstanceId=self.id)
-            except Exception as exc:  # noqa: BLE001 — boto3 may surface missing invocations as different exception types; we inspect the error code below
+            except Exception as exc:  # noqa: BLE001 — boto3 error type varies; classified by code below
                 if not _is_missing_invocation(exc):
                     raise
                 await asyncio.sleep(_POLL_INTERVAL)

--- a/ak-py/src/agentkernel/sandbox/providers/ec2_ssm.py
+++ b/ak-py/src/agentkernel/sandbox/providers/ec2_ssm.py
@@ -44,6 +44,7 @@ logger = logging.getLogger("ak.sandbox.provider")
 _HEREDOC_DELIMITER = "AK_SANDBOX_EOF"
 _POLL_INTERVAL = 1.0  # seconds between get_command_invocation polls
 _PENDING_STATUSES = {"Pending", "InProgress", "Delayed"}
+_MISSING_INVOCATION = "InvocationDoesNotExist"
 # STS RoleSessionName allows [\w+=,.@-] and 2-64 chars; anything else is replaced.
 _ROLE_SESSION_INVALID = re.compile(r"[^\w+=,.@-]")
 
@@ -120,7 +121,13 @@ class EC2SSMEnvironment(AttachedEnvironment):
     async def _poll(self, command_id: str) -> dict:
         """Poll ``get_command_invocation`` until the command reaches a terminal status."""
         while True:
-            invocation = await asyncio.to_thread(self._ssm.get_command_invocation, CommandId=command_id, InstanceId=self.id)
+            try:
+                invocation = await asyncio.to_thread(self._ssm.get_command_invocation, CommandId=command_id, InstanceId=self.id)
+            except Exception as exc:
+                if not _is_missing_invocation(exc):
+                    raise
+                await asyncio.sleep(_POLL_INTERVAL)
+                continue
             if invocation.get("Status") not in _PENDING_STATUSES:
                 return invocation
             await asyncio.sleep(_POLL_INTERVAL)
@@ -131,6 +138,12 @@ class EC2SSMEnvironment(AttachedEnvironment):
             await asyncio.to_thread(self._ssm.cancel_command, CommandId=command_id)
         except Exception as exc:  # noqa: BLE001 — the cancel is best-effort by contract
             logger.warning("Best-effort cancel of SSM command %s failed: %s", command_id, exc)
+
+
+def _is_missing_invocation(exc: Exception) -> bool:
+    """True when SSM has accepted the command but not yet registered its invocation."""
+    error_code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+    return error_code == _MISSING_INVOCATION or exc.__class__.__name__ == _MISSING_INVOCATION
 
 
 def _map_instance_error(exc: Exception, instance_id: str) -> Exception:

--- a/ak-py/tests/test_sandbox_providers.py
+++ b/ak-py/tests/test_sandbox_providers.py
@@ -433,6 +433,7 @@ class FakeSSMClient:
         self.cancel_calls = []
         self.describe_calls = []
         self.pending_polls = 0  # invocations report InProgress this many times before terminal
+        self.missing_polls = 0  # invocations raise InvocationDoesNotExist this many times first
         self.invocation = {
             "Status": "Success",
             "StandardOutputContent": "ssm stdout",
@@ -455,6 +456,9 @@ class FakeSSMClient:
 
     def get_command_invocation(self, CommandId, InstanceId):
         self.invocation_calls.append((CommandId, InstanceId))
+        if self.missing_polls > 0:  # SSM has not registered the invocation yet
+            self.missing_polls -= 1
+            raise FakeClientError("InvocationDoesNotExist")
         if self.pending_polls > 0:
             self.pending_polls -= 1
             return {"Status": "InProgress"}
@@ -565,6 +569,37 @@ async def test_ssm_polls_until_terminal_status(ssm_env):
         assert len(fake.ssm.invocation_calls) == 3  # two InProgress polls + the terminal one
     finally:
         module._POLL_INTERVAL = module_interval
+
+
+@pytest.mark.asyncio
+async def test_ssm_waits_out_unregistered_invocation(ssm_env):
+    """SendCommand -> GetCommandInvocation is eventually consistent; the gap is not a failure."""
+    module, fake = ssm_env
+    module_interval = module._POLL_INTERVAL
+    try:
+        module._POLL_INTERVAL = 0.01
+        provider = _ssm_provider(module)
+        principal, policy = _principal_policy()
+        sandbox = await provider.create(principal=principal, policy=policy)
+        fake.ssm.missing_polls = 2
+        result = await sandbox.execute_command("uname -a")
+        assert result.exit_code == 0 and result.stdout == "ssm stdout"
+        assert len(fake.ssm.invocation_calls) == 3  # two missing polls + the terminal one
+        assert len(fake.ssm.send_calls) == 1  # waited rather than re-sending
+    finally:
+        module._POLL_INTERVAL = module_interval
+
+
+@pytest.mark.asyncio
+async def test_ssm_unregistered_invocation_still_times_out(ssm_env):
+    """A never-registered invocation ends as SandboxTimeoutError, not an infinite wait."""
+    module, fake = ssm_env
+    provider = _ssm_provider(module)
+    principal, policy = _principal_policy()
+    sandbox = await provider.create(principal=principal, policy=policy)
+    fake.ssm.missing_polls = 10_000
+    with pytest.raises(SandboxTimeoutError):
+        await sandbox.execute_command("uname", timeout=0.05)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

`SendCommand` -> `GetCommandInvocation` is read-after-write eventually consistent in SSM, by roughly a second. The `ec2_ssm` provider's `_poll` issued its first `get_command_invocation` with zero delay and let the resulting `InvocationDoesNotExist` escape: `execute_command` catches only `asyncio.TimeoutError`, so the raw botocore `ClientError` propagated through `ExecutionManager.execute` into `sandbox/tools.py`, which returned it to the agent as `{"error": "... Invocation does not exist ..."}`.

The not-yet-registered state is the state *before* `Pending`, not a failure. This change makes `_poll` wait it out.

In-region callers lose this race nearly every time, since the round trips are fastest exactly where the gap is unchanged. In a downstream deployment (the p8 troubleshooter, Lambda and target instance in the same region) it took out **8 of 8** `kubectl` reads against a healthy host. The commands ran fine on the instance; only the result read was lost. Because the escaped error looks like a genuine AWS-side verdict, the agent then built a plausible but entirely wrong root cause around it — a supposed SSM delivery failure after a host restart.

Re-sending the command does not work around this: each new command races identically. The only fix is to keep polling, which is what this does.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update
- [ ] CI/CD update
- [ ] Other (please describe):

## Related Issues

No tracking issue; found in downstream use of `agentkernel==0.8.1`.

## Changes Made

- `sandbox/providers/ec2_ssm.py`: `_poll` catches `InvocationDoesNotExist` and keeps polling instead of letting it escape. `execute_command`'s existing `asyncio.wait_for` still bounds the loop, so an invocation that genuinely never appears ends as `SandboxTimeoutError` (with the best-effort cancel unchanged) rather than hanging.
- `sandbox/providers/ec2_ssm.py`: new `_is_missing_invocation` helper, detecting by error code in the same style as the neighbouring `_map_instance_error`. Deliberately not `self._ssm.exceptions.InvocationDoesNotExist` — the attribute form breaks on any client that isn't a real botocore client, and the code check also holds when botocore surfaces the error as a bare `ClientError`.
- `tests/test_sandbox_providers.py`: `FakeSSMClient` gains `missing_polls`, raising `InvocationDoesNotExist` N times before behaving normally.
- `tests/test_sandbox_providers.py`: two regression tests — the gap is waited out with a **single** `send_command` (asserting we wait rather than re-send), and a never-registered invocation still raises `SandboxTimeoutError`.

Scope kept deliberately narrow — two things this does *not* change:

- The gap is not mapped into the typed error hierarchy (`_map_instance_error` is untouched). Mapping it would change the exception surface for existing callers, and after this fix callers should not see the condition at all.
- `_assumed_role_client` still builds a fresh `botocore.session.get_session()`, so hooks registered on boto3's default session never reach user-mode clients. Not needed here now that the fix lives inside the provider, but it is worth knowing: it is why the external botocore `needs-retry` workaround downstream was fragile.

## Testing

- [x] Unit tests pass locally
- [ ] Integration tests pass locally
- [ ] Manual testing completed
- [x] New tests added for changes

`163 passed` across `tests/test_sandbox_providers.py` and `tests/test_sandbox.py`.

Not verified against live SSM — the failure mode is a timing race, and the tests reproduce it deterministically through the fake client instead. `ruff` is not installed in `ak-py/.venv`, so lint was not run locally; leaving that to CI.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Downstream consumers currently working around this from outside the framework — e.g. a botocore `needs-retry.ssm.GetCommandInvocation` hook on the default session — can drop that once this ships in a release.
