### PR TITLE
docs: add design spec for #553 OKF knowledge bases

### DIFF
--- a/.agents/skills/ak-dev-new-knowledgebase-integration/SKILL.md
+++ b/.agents/skills/ak-dev-new-knowledgebase-integration/SKILL.md
@@ -45,11 +45,22 @@ Implement a concrete class that extends `KnowledgeBase`:
 from typing import Any, Iterable, List, Mapping
 
 from .base import KnowledgeBase, Record
+from .model import KnowledgeCapabilities
 
 
 class MyBackendManager(KnowledgeBase):
     def __init__(self, name: str = "", description: str | None = None, **kwargs):
-        super().__init__()
+        # Declare only what this backend actually supports: an undeclared operation
+        # raises KnowledgeCapabilityError rather than returning an empty result.
+        super().__init__(
+            capabilities=KnowledgeCapabilities(
+                kinds=["vector"],
+                search=True,
+                search_mode="semantic",
+                writable=True,
+            ),
+            name=name,
+        )
         self.name = name
         self.description = description or "my backend"
         self._client = None
@@ -72,13 +83,40 @@ class MyBackendManager(KnowledgeBase):
             # Persist text + metadata using backend-native API.
             self._client.store(text=text, metadata=metadata)
 
-    def read(self, query: str, limit: int = 3, **kwargs) -> List[Mapping[str, Any]]:
+    def search(self, query: str, limit: int = 3, **kwargs) -> List[Mapping[str, Any]]:
         rows = self._client.search(query=query, limit=limit)
         return [{"text": row["text"], "metadata": row.get("metadata", {})} for row in rows]
 
     def get_description(self) -> str:
         return f"{self.backend_name}: {self.description}"
 ```
+
+`super().__init__(capabilities=...)` is required — the base takes no zero-argument form. Pass `name`
+too so a rejected declaration names your backend rather than the class.
+
+### 2a. Declare the Right Capability Set
+
+`backend_name`, `connect` and `get_description` are the only abstract members. Each retrieval and
+write operation is optional, and the declaration decides which ones you must implement:
+
+| Declare | Implement | Serves |
+|---|---|---|
+| `search` | `search(query, limit)` | `read_kb`, and `search_kb` when `query` is declared too |
+| `query` + `query_language` | `query(statement, limit)` | `read_kb` |
+| `fetch` | `fetch(ids)` | `fetch_kb` |
+| `browse` | `browse(path, limit)` | `browse_kb` |
+| `writable` | `write(records)` | `write_kb` |
+
+Rules `KnowledgeBase.__init__` enforces:
+
+- At least one of `search` / `query` / `fetch` / `browse` / `writable` must be `True`.
+- `query=True` requires a `query_language` (`"cypher"`, `"sql"`, …), and a `query_language` requires
+  `query=True`.
+
+Never implement `read()`. It is concrete and routes on the declaration — to `query()` when `query` is
+declared, to `search()` otherwise — which is what lets one `read_kb` tool serve every backend.
+Declaring `fetch` also makes `format_results()` prefix each line with the record's `metadata["id"]`,
+so give every record an `id` containing no `,` (`fetch_kb` splits id lists on it).
 
 ### 3. Respect the Record Contract
 
@@ -87,18 +125,23 @@ All reads must return normalized rows compatible with `KnowledgeBuilder`:
 
 All writes accept the same shape through `write(records=[...])`.
 
-If the provider result is not in this shape, normalize inside `read()`.
+If the provider result is not in this shape, normalize inside `search()` / `query()` / `fetch()` / `browse()`.
 
 ### 4. Define Backend Constraints Explicitly
 
-If the backend is read-only, enforce it in code:
+If the backend is read-only, say so in the declaration and implement nothing:
 
 ```python
-def write(self, records, **kwargs) -> None:
-    raise NotImplementedError("This backend is read-only.")
+super().__init__(
+    capabilities=KnowledgeCapabilities(kinds=["structured"], query=True, query_language="sql", writable=False),
+    name=name,
+)
 ```
 
-Do not silently ignore writes.
+`KnowledgeBase.write()` then raises `KnowledgeCapabilityError(backend_name, "write")` on its own, and
+`KnowledgeBuilder` gates `write_kb` before it ever reaches you. Do not override `write()` to raise —
+that only duplicates the base — and never silently ignore writes. The same holds for every other
+operation: leave undeclared ones unimplemented rather than raising by hand.
 
 ### 5. Add Robust Connection Handling
 

--- a/ak-py/src/agentkernel/knowledgebase/__init__.py
+++ b/ak-py/src/agentkernel/knowledgebase/__init__.py
@@ -1,1 +1,24 @@
-# Knowledge base backends for Agent Kernel
+"""Knowledge base backends for Agent Kernel.
+
+Only the capability model, the record typing and the error hierarchy are re-exported
+here. The backends themselves stay behind their own modules on purpose: each pulls an
+optional SDK (``chromadb``, ``neo4j``, ``trino``), so importing this package must not
+require any of them.
+"""
+
+from .base import KnowledgeBase, Record
+from .errors import KnowledgeCapabilityError, KnowledgeError, KnowledgePathError
+from .knowledgebuilder import KnowledgeBuilder
+from .model import KnowledgeCapabilities, KnowledgeMetadata, KnowledgeRecord
+
+__all__ = [
+    "KnowledgeBase",
+    "KnowledgeBuilder",
+    "KnowledgeCapabilities",
+    "KnowledgeCapabilityError",
+    "KnowledgeError",
+    "KnowledgeMetadata",
+    "KnowledgePathError",
+    "KnowledgeRecord",
+    "Record",
+]

--- a/ak-py/src/agentkernel/knowledgebase/base.py
+++ b/ak-py/src/agentkernel/knowledgebase/base.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Mapping
 
+from .errors import KnowledgeCapabilityError
+from .model import KnowledgeCapabilities
+
 Record = Mapping[str, Any]
 
 
@@ -9,24 +12,65 @@ class KnowledgeBase(ABC):
     Backend-agnostic contract for all knowledge base implementations.
 
     To add a new backend, subclass this and implement:
-      - connect()
-      - write()
-      - read()
       - backend_name
+      - connect()
       - get_description()
 
-    Backends can also receive runtime schema configuration via add_schema().
-    The schema() method is an instance method that returns the configured
-    schema describing what this backend stores and how.
+    Then declare what the backend supports in a :class:`KnowledgeCapabilities` passed
+    to ``super().__init__()``, and implement the matching operations from
+    ``search`` / ``query`` / ``fetch`` / ``browse`` / ``write``. Every operation is
+    optional; an undeclared one raises :class:`KnowledgeCapabilityError`, so the
+    declaration and the implemented set must agree.
+
+    ``read()`` is concrete and routes to ``query()`` or ``search()`` on the declaration,
+    which is what lets one agent tool serve every backend.
+
+    Backends can also receive runtime schema configuration via add_schema(), or
+    self-describe by overriding _derived_schema(). The schema() method is an instance
+    method that returns the configured schema describing what this backend stores and how.
     """
 
-    def __init__(self):
-        """
-        Initialize base knowledge backend state.
+    capabilities: KnowledgeCapabilities
 
-        :return: None.
+    def __init__(self, capabilities: KnowledgeCapabilities, name: str | None = None) -> None:
         """
-        self._dynamic_schema = {}
+        Initialize base knowledge backend state and validate the declaration.
+
+        :param capabilities: What this backend supports.
+        :param name: Backend name used in validation errors. Defaults to the class name.
+        :return: None.
+        :raises ValueError: If the declaration is unreachable or query-incoherent.
+        """
+        self._dynamic_schema: dict[str, Any] = {}
+        self.capabilities = capabilities
+        # backend_name is deliberately not read here: subclasses call super().__init__()
+        # before assigning the attributes the property depends on. The operations below
+        # may read it, because by then the subclass is fully constructed.
+        self.validate_capabilities(capabilities, name or type(self).__name__)
+
+    @staticmethod
+    def validate_capabilities(capabilities: KnowledgeCapabilities, subject: str) -> None:
+        """
+        Reject a capability declaration no backend could honour.
+
+        Static so the reusable backend contract can exercise it without constructing
+        a backend.
+
+        :param capabilities: Declaration to check.
+        :param subject: Backend name used in the error messages.
+        :return: None.
+        :raises ValueError: If the declaration is unreachable or query-incoherent.
+        """
+        # Reachability is checked first so a backend declaring nothing at all reports the
+        # more fundamental problem rather than a query-language detail.
+        if not (capabilities.search or capabilities.query or capabilities.fetch or capabilities.browse or capabilities.writable):
+            raise ValueError(
+                f"Knowledge backend '{subject}' declares no capability: at least one of " "search, query, fetch, browse, writable must be True."
+            )
+        if capabilities.query and not (capabilities.query_language or "").strip():
+            raise ValueError(f"Knowledge backend '{subject}' declares query=True without a query_language.")
+        if not capabilities.query and (capabilities.query_language or "").strip():
+            raise ValueError(f"Knowledge backend '{subject}' declares query_language " f"{capabilities.query_language!r} without query=True.")
 
     @property
     @abstractmethod
@@ -47,18 +91,34 @@ class KnowledgeBase(ABC):
         self._dynamic_schema.update(schema_config)
         return self
 
+    def _derived_schema(self) -> Mapping[str, Any]:
+        """
+        Return a schema the backend can describe by itself, without add_schema().
+
+        Backends declaring ``derives_schema`` must return a non-empty mapping here.
+
+        :return: Derived schema mapping; empty when the backend cannot self-describe.
+        """
+        return {}
+
     def schema(self) -> Mapping[str, Any]:
         """
         Return the backend schema exposed to the agent.
 
-        :return: Final schema mapping including backend identity.
-        :raises ValueError: If no schema has been configured.
+        :return: Final schema mapping including backend identity and capabilities.
+        :raises ValueError: If neither add_schema() nor _derived_schema() supplied a schema.
         """
-        if not self._dynamic_schema:
+        derived = dict(self._derived_schema())
+        # backend and capabilities do not count as content, so the guard runs before they are added.
+        if not self._dynamic_schema and not derived:
             raise ValueError(f"Schema for '{self.backend_name}' has not been set! " "Call .add_schema() before passing to the Agent.")
 
-        final_schema = {"backend": self.backend_name}
+        final_schema: dict[str, Any] = {"backend": self.backend_name}
+        final_schema.update(derived)
         final_schema.update(self._dynamic_schema)
+        # Written last and therefore not overridable: capabilities is the declaration the
+        # tool layer routes on, and a deployment must not be able to contradict it.
+        final_schema["capabilities"] = self.capabilities.model_dump()
         return final_schema
 
     @abstractmethod
@@ -70,7 +130,53 @@ class KnowledgeBase(ABC):
         :return: None.
         """
 
-    @abstractmethod
+    def search(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
+        """
+        Return the most relevant records for a natural-language query.
+
+        :param query: Natural-language query text.
+        :param limit: Maximum number of records to return.
+        :param kwargs: Backend-specific search options.
+        :return: List of matched records.
+        :raises KnowledgeCapabilityError: If the backend does not declare ``search``.
+        """
+        raise KnowledgeCapabilityError(self.backend_name, "search")
+
+    def query(self, statement: str, limit: int = 3, **kwargs) -> List[Record]:
+        """
+        Execute a query-language statement and return the resulting records.
+
+        :param statement: Statement in the backend's declared ``query_language``.
+        :param limit: Maximum number of records to return.
+        :param kwargs: Backend-specific query options.
+        :return: List of resulting records.
+        :raises KnowledgeCapabilityError: If the backend does not declare ``query``.
+        """
+        raise KnowledgeCapabilityError(self.backend_name, "query")
+
+    def fetch(self, ids: List[str], **kwargs) -> List[Record]:
+        """
+        Return records by their backend-native identities.
+
+        :param ids: Record identities to retrieve.
+        :param kwargs: Backend-specific fetch options.
+        :return: List of retrieved records; unknown identities are omitted.
+        :raises KnowledgeCapabilityError: If the backend does not declare ``fetch``.
+        """
+        raise KnowledgeCapabilityError(self.backend_name, "fetch")
+
+    def browse(self, path: str = "", limit: int = 50, **kwargs) -> List[Record]:
+        """
+        Enumerate what the backend holds under a namespace.
+
+        :param path: Namespace to enumerate; empty means the top level.
+        :param limit: Maximum number of entries to return.
+        :param kwargs: Backend-specific browse options.
+        :return: List of records describing the namespace contents.
+        :raises KnowledgeCapabilityError: If the backend does not declare ``browse``.
+        """
+        raise KnowledgeCapabilityError(self.backend_name, "browse")
+
     def write(self, records: Iterable[Record], **kwargs) -> None:
         """
         Persist one or more records into the backend.
@@ -78,29 +184,51 @@ class KnowledgeBase(ABC):
         :param records: Records to persist.
         :param kwargs: Backend-specific write options.
         :return: None.
+        :raises KnowledgeCapabilityError: If the backend does not declare ``writable``.
         """
+        raise KnowledgeCapabilityError(self.backend_name, "write")
 
-    @abstractmethod
     def read(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
         """
-        Return the most relevant records for a query.
+        Return the most relevant records for a query, routing on the declaration.
+
+        Backends declaring ``query`` receive the text as a statement; every other
+        backend receives it as a relevance search. This is the single entrypoint the
+        generic read tool uses, so one tool serves every backend.
 
         :param query: Backend-specific query string.
         :param limit: Maximum number of records to return.
-        :param kwargs: Backend-specific read options.
+        :param kwargs: Backend-specific read options, forwarded unchanged.
         :return: List of matched records.
         """
+        if self.capabilities.query:
+            return self.query(query, limit=limit, **kwargs)
+        return self.search(query, limit=limit, **kwargs)
 
     def format_results(self, rows: List[Record]) -> str:
         """
         Format backend records into a readable string for the agent.
+
+        Backends declaring ``fetch`` prefix each line with the record identity, so the
+        agent can feed it straight back to the fetch tool.
 
         :param rows: Records returned by a backend read.
         :return: Human-readable formatted output.
         """
         if not rows:
             return "No relevant knowledge found."
-        return "\n".join(f"- {r.get('text', '')} (source: {r.get('metadata', {}).get('source', 'N/A')})" for r in rows)
+
+        lines = []
+        for row in rows:
+            metadata = row.get("metadata", {}) or {}
+            text, source = row.get("text", ""), metadata.get("source", "N/A")
+            record_id = metadata.get("id")
+            # An unusable id degrades to the plain line rather than rendering "[None]".
+            if self.capabilities.fetch and isinstance(record_id, str) and record_id:
+                lines.append(f"- [{record_id}] {text} (source: {source})")
+            else:
+                lines.append(f"- {text} (source: {source})")
+        return "\n".join(lines)
 
     def close(self) -> None:
         """

--- a/ak-py/src/agentkernel/knowledgebase/chroma.py
+++ b/ak-py/src/agentkernel/knowledgebase/chroma.py
@@ -6,6 +6,7 @@ import chromadb
 from chromadb.utils import embedding_functions
 
 from .base import KnowledgeBase
+from .model import KnowledgeCapabilities
 
 log = logging.getLogger("ak.ChromaManager")
 
@@ -35,7 +36,10 @@ class ChromaManager(KnowledgeBase):
             If omitted, the default Chroma embedding function is used.
         :return: None.
         """
-        super().__init__()
+        super().__init__(
+            capabilities=KnowledgeCapabilities(kinds=["vector"], search=True, search_mode="semantic", writable=True),
+            name=name,
+        )
         self.persist_path = persist_path
         self.client = None
         self.collection = None
@@ -99,7 +103,7 @@ class ChromaManager(KnowledgeBase):
         if texts:
             self.collection.upsert(documents=texts, metadatas=metadatas, ids=ids)
 
-    def read(self, query: str, limit: int = 3, **kwargs) -> List[Mapping[str, Any]]:
+    def search(self, query: str, limit: int = 3, **kwargs) -> List[Mapping[str, Any]]:
         """
         Query the Chroma collection for semantically similar documents.
 

--- a/ak-py/src/agentkernel/knowledgebase/errors.py
+++ b/ak-py/src/agentkernel/knowledgebase/errors.py
@@ -1,0 +1,47 @@
+"""Exception hierarchy for the knowledge-base capability.
+
+Every knowledge-base failure is a subclass of :class:`KnowledgeError`. Finding nothing
+is NOT an error here — a read that matches no records returns an empty list, and a
+malformed document is skipped with a diagnostic. These exceptions signal failures of the
+knowledge-base *machinery* only, and the tool surface catches them to return an
+actionable string to the agent rather than letting them reach the framework.
+"""
+
+
+class KnowledgeError(Exception):
+    """Base class for all knowledge-base capability errors."""
+
+
+class KnowledgeCapabilityError(KnowledgeError):
+    """An operation the backend does not declare in its ``KnowledgeCapabilities``.
+
+    Raised either as ``KnowledgeCapabilityError(subject, operation)`` (e.g. the backend
+    name plus the missing operation) or ``KnowledgeCapabilityError(operation)``.
+
+    Deliberately not a ``NotImplementedError``: that would be indistinguishable from an
+    unimplemented abstract method, and this is a declaration mismatch the tool boundary
+    is expected to catch and explain.
+    """
+
+    def __init__(self, *args: str) -> None:
+        """Accept ``(subject, operation)`` or ``(operation,)`` and build the message."""
+        self.subject: str | None = None
+        self.capability: str = ""
+        if len(args) == 2:
+            self.subject, self.capability = args[0], args[1]
+            message = f"{self.subject} does not support capability: {self.capability}"
+        elif len(args) == 1:
+            self.capability = args[0]
+            message = f"unsupported capability: {self.capability}"
+        else:
+            message = ""
+        super().__init__(message)
+
+
+class KnowledgePathError(KnowledgeError):
+    """A path escaped the store's namespace, or is otherwise unusable as an identity.
+
+    Raised by ``DocumentStore`` implementations and mapped to an agent-facing result by
+    ``DocumentKnowledgeBase``; a distinct type so that mapping does not have to catch
+    ``ValueError`` and swallow unrelated failures.
+    """

--- a/ak-py/src/agentkernel/knowledgebase/knowledgebuilder.py
+++ b/ak-py/src/agentkernel/knowledgebase/knowledgebuilder.py
@@ -115,27 +115,34 @@ class KnowledgeBuilder:
         capabilities = self._capabilities_of(backend)
         return bool(capabilities and getattr(capabilities, capability, False))
 
-    def _backends_declaring(self, capability: str) -> List[str]:
+    def _backends_declaring(self, *capabilities: str) -> List[str]:
         """
-        List the registered backends declaring a capability.
+        List the registered backends declaring at least one of the given capabilities.
 
         Used both to gate which tools ``build()`` emits and to tell an agent which
-        backends a mis-routed call should have gone to.
+        backends a mis-routed call should have gone to. More than one capability is
+        passed when a single tool is served by several, as read_kb is by search and query.
 
-        :param capability: KnowledgeCapabilities field name, for example "browse".
-        :return: Backend names declaring that capability, in registration order.
+        :param capabilities: KnowledgeCapabilities field names, for example "browse".
+        :return: Backend names declaring at least one of them, in registration order.
         """
-        return [name for name, backend in self.backends.items() if self._declares(backend, capability)]
+        return [name for name, backend in self.backends.items() if any(self._declares(backend, field) for field in capabilities)]
 
-    def _unsupported(self, backend_name: str, capability: str) -> str:
+    def _unsupported(self, backend_name: str, label: str, *capabilities: str) -> str:
         """
         Build the message returned when a tool is routed at a backend that cannot serve it.
 
+        The label is what the agent reads, and the capability fields are what decides who
+        can serve it instead. They differ where no single field carries the tool's name:
+        read_kb needs search or query, and write_kb needs the field spelled ``writable``.
+
         :param backend_name: Backend the agent addressed.
-        :param capability: Capability the tool needs.
+        :param label: What the tool needs, phrased for the agent.
+        :param capabilities: Fields that satisfy the need; defaults to the label itself.
         :return: Message naming the backends that do declare the capability.
         """
-        return f"Backend '{backend_name}' does not support {capability}. Backends that do: {self._backends_declaring(capability)}."
+        alternatives = self._backends_declaring(*(capabilities or (label,)))
+        return f"Backend '{backend_name}' does not support {label}. Backends that do: {alternatives}."
 
     def build(self):
         """
@@ -185,6 +192,11 @@ class KnowledgeBuilder:
             if not db:
                 return f"Unknown backend '{backend}'. Available: {list(self.backends.keys())}"
 
+            # read() falls through to search() whenever query is undeclared, so a backend
+            # declaring neither would report a missing search the agent never asked for.
+            if not self._declares(db, "search") and not self._declares(db, "query"):
+                return self._unsupported(backend, "reads", "search", "query")
+
             resolved_query = self._resolve_placeholders(query)
             if resolved_query != query:
                 log.debug(f"[read_kb] Translated query to: {resolved_query!r}")
@@ -211,6 +223,9 @@ class KnowledgeBuilder:
             db = self.backends.get(backend)
             if not db:
                 return f"Unknown backend '{backend}'."
+
+            if not self._declares(db, "writable"):
+                return self._unsupported(backend, "writes", "writable")
 
             if not text and not query:
                 return "Error: provide at least one of 'text' or 'query'."

--- a/ak-py/src/agentkernel/knowledgebase/knowledgebuilder.py
+++ b/ak-py/src/agentkernel/knowledgebase/knowledgebuilder.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from .base import KnowledgeBase
+from .model import KnowledgeCapabilities
 
 log = logging.getLogger("ak.KnowledgeBuilder")
 
@@ -88,12 +89,71 @@ class KnowledgeBuilder:
                 resolved_text = resolved_text.replace(logical_tag, physical_path)
         return resolved_text
 
+    @staticmethod
+    def _capabilities_of(backend: KnowledgeBase) -> Optional[KnowledgeCapabilities]:
+        """
+        Return a backend's capability declaration, or None when it has none.
+
+        A subclass that overrides ``__init__`` without calling ``super().__init__()``
+        never gets a declaration. That is a bug in the backend, but it must not take
+        down tool construction for every other backend, so it reads as "declares
+        nothing" rather than raising AttributeError.
+
+        :param backend: Registered backend to inspect.
+        :return: The declaration, or None when the backend never declared one.
+        """
+        return getattr(backend, "capabilities", None)
+
+    def _declares(self, backend: KnowledgeBase, capability: str) -> bool:
+        """
+        Report whether one backend declares a capability.
+
+        :param backend: Registered backend to inspect.
+        :param capability: KnowledgeCapabilities field name, for example "fetch".
+        :return: True when the backend declares that capability.
+        """
+        capabilities = self._capabilities_of(backend)
+        return bool(capabilities and getattr(capabilities, capability, False))
+
+    def _backends_declaring(self, capability: str) -> List[str]:
+        """
+        List the registered backends declaring a capability.
+
+        Used both to gate which tools ``build()`` emits and to tell an agent which
+        backends a mis-routed call should have gone to.
+
+        :param capability: KnowledgeCapabilities field name, for example "browse".
+        :return: Backend names declaring that capability, in registration order.
+        """
+        return [name for name, backend in self.backends.items() if self._declares(backend, capability)]
+
+    def _unsupported(self, backend_name: str, capability: str) -> str:
+        """
+        Build the message returned when a tool is routed at a backend that cannot serve it.
+
+        :param backend_name: Backend the agent addressed.
+        :param capability: Capability the tool needs.
+        :return: Message naming the backends that do declare the capability.
+        """
+        return f"Backend '{backend_name}' does not support {capability}. Backends that do: {self._backends_declaring(capability)}."
+
     def build(self):
         """
         Build and return callable tools for schema discovery, reads, and writes.
 
+        Four tools are always returned. Up to three more are appended, each only when
+        some registered backend declares the capability behind it, so an application's
+        agent never sees a tool nothing can serve.
+
         :return: List of callable tool functions.
         """
+        for name, backend in self.backends.items():
+            if self._capabilities_of(backend) is None:
+                log.warning(
+                    "[build] Backend %r has no capabilities declaration and will be treated as declaring nothing. "
+                    "Its __init__ must call super().__init__(capabilities=...).",
+                    name,
+                )
 
         def get_schemas() -> str:
             """
@@ -102,7 +162,14 @@ class KnowledgeBuilder:
             :return: JSON string containing backend schema definitions.
             """
             log.debug(f"[get_schemas] backends={list(self.backends.keys())}")
-            return json.dumps({name: backend.schema() for name, backend in self.backends.items()}, indent=2)
+            schemas: dict[str, Any] = {}
+            for name, backend in self.backends.items():
+                try:
+                    schemas[name] = backend.schema()
+                except Exception as e:
+                    log.error(f"[get_schemas] Schema error on {name}: {e}")
+                    schemas[name] = {"error": str(e)}
+            return json.dumps(schemas, indent=2)
 
         def read_kb(backend: str, query: str, limit: int = 3) -> str:
             """
@@ -154,7 +221,6 @@ class KnowledgeBuilder:
             metadata: dict[str, Any] = {"source": source}
             if resolved_query:
                 metadata["query"] = resolved_query
-                metadata["cypher_query"] = resolved_query
                 try:
                     parsed_params = json.loads(params_json)
                 except Exception:
@@ -164,7 +230,6 @@ class KnowledgeBuilder:
                     return "Error: params_json must be a valid JSON object string."
 
                 metadata["params"] = parsed_params
-                metadata["cypher_params"] = parsed_params
 
             try:
                 db.write([{"text": text, "metadata": metadata}])
@@ -187,4 +252,108 @@ class KnowledgeBuilder:
                     descriptions.append(f"{name}: Error retrieving description ({e})")
             return "\n".join(descriptions)
 
-        return [get_schemas, read_kb, write_kb, get_all_kb_descriptions]
+        def search_kb(backend: str, query: str, limit: int = 3) -> str:
+            """
+            Find the knowledge most relevant to a natural-language question.
+
+            Use this instead of read_kb when the backend also accepts a query language
+            and you want relevance ranking rather than an exact statement.
+
+            :param backend: Backend name to search, as returned by get_schemas().
+            :param query: Natural-language description of what you are looking for.
+            :param limit: Maximum number of results to return.
+            :return: Formatted search result string or error message.
+            """
+            log.debug(f"[search_kb] backend={backend!r} raw_query={query!r}")
+            db = self.backends.get(backend)
+            if not db:
+                return f"Unknown backend '{backend}'. Available: {list(self.backends.keys())}"
+
+            if not self._declares(db, "search"):
+                return self._unsupported(backend, "search")
+
+            resolved_query = self._resolve_placeholders(query)
+            if resolved_query != query:
+                log.debug(f"[search_kb] Translated query to: {resolved_query!r}")
+
+            try:
+                results = db.search(resolved_query, limit=limit)
+                return db.format_results(results)
+            except Exception as e:
+                log.error(f"[search_kb] Execution error on {backend}: {e}")
+                return f"Execution Error: {str(e)}"
+
+        def fetch_kb(backend: str, ids: str) -> str:
+            """
+            Retrieve specific records by the identities a previous result showed.
+
+            Identities appear in square brackets at the start of each result line.
+
+            :param backend: Backend name to fetch from, as returned by get_schemas().
+            :param ids: One identity, or several separated by commas.
+            :return: Formatted records string or error message.
+            """
+            log.debug(f"[fetch_kb] backend={backend!r} raw_ids={ids!r}")
+            db = self.backends.get(backend)
+            if not db:
+                return f"Unknown backend '{backend}'. Available: {list(self.backends.keys())}"
+
+            if not self._declares(db, "fetch"):
+                return self._unsupported(backend, "fetch")
+
+            # Resolution runs per segment, after the split, so a placeholder standing for a
+            # namespace root resolves the same way whether it arrives alone or in a list.
+            resolved_ids = [self._resolve_placeholders(segment) for segment in (raw.strip() for raw in ids.split(",")) if segment]
+            if not resolved_ids:
+                return "Error: provide at least one id."
+
+            try:
+                results = db.fetch(resolved_ids)
+                return db.format_results(results)
+            except Exception as e:
+                log.error(f"[fetch_kb] Execution error on {backend}: {e}")
+                return f"Execution Error: {str(e)}"
+
+        def browse_kb(backend: str, path: str = "", limit: int = 50) -> str:
+            """
+            List what a knowledge base holds under a namespace, without searching it.
+
+            Use this to discover what is available before fetching or searching.
+
+            :param backend: Backend name to browse, as returned by get_schemas().
+            :param path: Namespace to list; empty lists the top level.
+            :param limit: Maximum number of entries to return.
+            :return: Formatted listing string or error message.
+            """
+            log.debug(f"[browse_kb] backend={backend!r} raw_path={path!r}")
+            db = self.backends.get(backend)
+            if not db:
+                return f"Unknown backend '{backend}'. Available: {list(self.backends.keys())}"
+
+            if not self._declares(db, "browse"):
+                return self._unsupported(backend, "browse")
+
+            resolved_path = self._resolve_placeholders(path)
+            if resolved_path != path:
+                log.debug(f"[browse_kb] Translated path to: {resolved_path!r}")
+
+            try:
+                results = db.browse(resolved_path, limit=limit)
+                return db.format_results(results)
+            except Exception as e:
+                log.error(f"[browse_kb] Execution error on {backend}: {e}")
+                return f"Execution Error: {str(e)}"
+
+        tools = [get_schemas, read_kb, write_kb, get_all_kb_descriptions]
+
+        # search_kb has the narrowest gate of the three: for a search-only backend read_kb
+        # already reaches search(), so the tool is only worth its slot in the prompt once a
+        # backend declares query as well and read() therefore routes away from search().
+        if any(self._declares(backend, "search") and self._declares(backend, "query") for backend in self.backends.values()):
+            tools.append(search_kb)
+        if self._backends_declaring("fetch"):
+            tools.append(fetch_kb)
+        if self._backends_declaring("browse"):
+            tools.append(browse_kb)
+
+        return tools

--- a/ak-py/src/agentkernel/knowledgebase/model.py
+++ b/ak-py/src/agentkernel/knowledgebase/model.py
@@ -1,0 +1,61 @@
+"""Knowledge-base capability declaration and record typing.
+
+A backend declares what it actually supports in a :class:`KnowledgeCapabilities`;
+:class:`agentkernel.knowledgebase.base.KnowledgeBase` routes on that declaration and
+``KnowledgeBuilder`` gates its agent tools on it. An operation a backend does not
+declare raises :class:`agentkernel.knowledgebase.errors.KnowledgeCapabilityError`
+rather than returning an empty result, so an honest declaration is load-bearing.
+
+The two ``TypedDict``s here document the record shape that travels between backends
+and tools. They are never validated at runtime — ``Record = Mapping[str, Any]``
+stays the annotation on every signature.
+"""
+
+from typing import Literal, TypedDict
+
+from pydantic import BaseModel, Field
+
+
+class KnowledgeCapabilities(BaseModel):
+    """What a backend actually supports; undeclared operations raise ``KnowledgeCapabilityError``."""
+
+    # Intentionally free of cross-field validators. The two invariants a declaration must
+    # satisfy — being reachable at all, and query/query_language coherence — are enforced in
+    # KnowledgeBase.__init__, because each error has to name the offending backend and a
+    # capabilities object does not know its owner. An application can therefore build one of
+    # these for inspection without owning a backend.
+
+    kinds: list[str] = Field(default_factory=list)  # open taxonomy: vector|structured|graph|document|…
+    search: bool = False  # relevance retrieval
+    search_mode: Literal["semantic", "lexical"] | None = None  # advisory only; deliberately not bidirectional with search
+    query: bool = False  # query-language retrieval
+    query_language: str | None = None  # e.g. "cypher", "sql"
+    fetch: bool = False  # retrieval by identity
+    browse: bool = False  # namespace enumeration
+    writable: bool = False
+    derives_schema: bool = False  # schema() self-describes without add_schema()
+
+
+class KnowledgeMetadata(TypedDict, total=False):
+    """Conventional metadata keys on a record; documentation-only, never validated.
+
+    ``id`` is required in the metadata of every record a backend declaring ``fetch``
+    returns, and must contain no ``,`` (the tool surface splits id lists on it). That
+    rule is asserted by ``KnowledgeBaseContract``, not at runtime — a backend is free
+    to carry keys beyond these.
+    """
+
+    id: str  # backend-native identity
+    source: str
+    title: str
+    kind: str
+    trust: str
+    stale: bool
+    links: list[str]
+
+
+class KnowledgeRecord(TypedDict, total=False):
+    """One record as backends return it and tools format it; documentation-only, never validated."""
+
+    text: str
+    metadata: KnowledgeMetadata

--- a/ak-py/src/agentkernel/knowledgebase/neo4j.py
+++ b/ak-py/src/agentkernel/knowledgebase/neo4j.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, List, Mapping
 from neo4j import GraphDatabase
 
 from .base import KnowledgeBase
+from .errors import KnowledgeError
 from .model import KnowledgeCapabilities
 
 log = logging.getLogger("ak.Neo4jManager")
@@ -116,13 +117,17 @@ class Neo4jManager(KnowledgeBase):
         Persist records to Neo4j by executing the Cypher carried in each record's metadata.
 
         Reads ``metadata["query"]`` and ``metadata["params"]``, falling back to the
-        legacy ``cypher_query`` / ``cypher_params`` names. A record carrying neither is
-        skipped with a warning.
+        legacy ``cypher_query`` / ``cypher_params`` names. A record carrying neither
+        cannot be stored by this backend: it is skipped so the rest of the batch still
+        runs, and the skips are reported once the batch is through. Reporting them is
+        what stops the tool layer from calling a write that stored nothing a success.
 
         :param records: Iterable of records with text and metadata fields.
         :param kwargs: Additional keyword arguments reserved for interface compatibility.
         :return: None.
+        :raises KnowledgeError: If any record carried no Cypher; raised after the rest ran.
         """
+        stored, skipped = 0, 0
         for record in records:
             meta = dict(record.get("metadata", {}))
             # cypher_* are the pre-#553 key names, still read so a caller that has not
@@ -132,9 +137,17 @@ class Neo4jManager(KnowledgeBase):
 
             if not statement:
                 log.warning("[neo4j.write] record carries no query; skipping. metadata keys=%s", sorted(meta))
+                skipped += 1
                 continue
 
             self._run(statement, params)
+            stored += 1
+
+        if skipped:
+            raise KnowledgeError(
+                f"[KB][{self.backend_name}] {skipped} of {stored + skipped} record(s) carried no Cypher and were not stored "
+                f"({stored} stored). A Neo4j write needs the statement in metadata['query']."
+            )
 
     def query(self, statement: str, limit: int = 3, **kwargs) -> List[Mapping[str, Any]]:
         """

--- a/ak-py/src/agentkernel/knowledgebase/neo4j.py
+++ b/ak-py/src/agentkernel/knowledgebase/neo4j.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, List, Mapping
 from neo4j import GraphDatabase
 
 from .base import KnowledgeBase
+from .model import KnowledgeCapabilities
 
 log = logging.getLogger("ak.Neo4jManager")
 
@@ -38,7 +39,10 @@ class Neo4jManager(KnowledgeBase):
         :return: None.
         """
 
-        super().__init__()
+        super().__init__(
+            capabilities=KnowledgeCapabilities(kinds=["graph", "structured"], query=True, query_language="cypher", writable=True),
+            name=name,
+        )
 
         self.uri = uri or os.getenv("NEO4J_URI", "bolt://localhost:7687")
         self.user = user or os.getenv("NEO4J_USERNAME", "neo4j")
@@ -109,7 +113,11 @@ class Neo4jManager(KnowledgeBase):
 
     def write(self, records: Iterable[Mapping[str, Any]], **kwargs) -> None:
         """
-        Persist records to Neo4j using either raw Cypher metadata or note upserts.
+        Persist records to Neo4j by executing the Cypher carried in each record's metadata.
+
+        Reads ``metadata["query"]`` and ``metadata["params"]``, falling back to the
+        legacy ``cypher_query`` / ``cypher_params`` names. A record carrying neither is
+        skipped with a warning.
 
         :param records: Iterable of records with text and metadata fields.
         :param kwargs: Additional keyword arguments reserved for interface compatibility.
@@ -117,16 +125,22 @@ class Neo4jManager(KnowledgeBase):
         """
         for record in records:
             meta = dict(record.get("metadata", {}))
-            cypher_query = meta.get("cypher_query")
-            cypher_params = meta.get("cypher_params") or {}
+            # cypher_* are the pre-#553 key names, still read so a caller that has not
+            # migrated keeps working.
+            statement = meta.get("query") or meta.get("cypher_query")
+            params = meta.get("params") or meta.get("cypher_params") or {}
 
-            self._run(cypher_query, cypher_params)
+            if not statement:
+                log.warning("[neo4j.write] record carries no query; skipping. metadata keys=%s", sorted(meta))
+                continue
 
-    def read(self, query: str, limit: int = 10, **kwargs) -> List[Mapping[str, Any]]:
+            self._run(statement, params)
+
+    def query(self, statement: str, limit: int = 3, **kwargs) -> List[Mapping[str, Any]]:
         """
         Execute a Cypher read query and return normalized records.
 
-        :param query: Cypher query to execute.
+        :param statement: Cypher query to execute.
         :param limit: Maximum number of records requested by the caller.
         :param kwargs: Additional keyword arguments reserved for interface compatibility.
         :return: List of normalized records for the knowledge interface.
@@ -135,7 +149,7 @@ class Neo4jManager(KnowledgeBase):
         if limit <= 0:
             return []
 
-        normalized_query = query.strip().rstrip(";")
+        normalized_query = statement.strip().rstrip(";")
         if not normalized_query:
             return []
 

--- a/ak-py/src/agentkernel/knowledgebase/starburst.py
+++ b/ak-py/src/agentkernel/knowledgebase/starburst.py
@@ -1,12 +1,11 @@
 import logging
 import os
-from typing import Any, Iterable, List, Mapping, Optional
+from typing import Any, List, Mapping
 
 import trino
 import trino.exceptions
 
 from .base import KnowledgeBase
-from .errors import KnowledgeCapabilityError
 from .model import KnowledgeCapabilities
 
 logger = logging.getLogger("ak.StarburstManager")
@@ -133,17 +132,6 @@ class StarburstManager(KnowledgeBase):
                 logger.warning(f"[KB][{self.name}] Close error: {exc}")
             finally:
                 self.connection = None
-
-    def write(self, records: Optional[Iterable[Mapping[str, Any]]] = None, **kwargs) -> None:
-        """
-        Reject write attempts because this backend is read-only.
-
-        :param records: Unused write payload.
-        :param kwargs: Reserved for interface compatibility.
-        :return: None.
-        :raises KnowledgeCapabilityError: Always raised for this backend.
-        """
-        raise KnowledgeCapabilityError(self.backend_name, "write")
 
     def get_description(self) -> str:
         """

--- a/ak-py/src/agentkernel/knowledgebase/starburst.py
+++ b/ak-py/src/agentkernel/knowledgebase/starburst.py
@@ -21,6 +21,7 @@ STARBURST_PORT = int(os.getenv("STARBURST_PORT", "443"))
 # the fallback and exposing the whole table; requiring the count also excludes columns/string literals.
 LIMIT_CLAUSE = re.compile(r"\bLIMIT\s+(?:\d+|ALL)\b", re.IGNORECASE)
 
+
 class StarburstManager(KnowledgeBase):
     """
     Read-only Starburst Galaxy backend.

--- a/ak-py/src/agentkernel/knowledgebase/starburst.py
+++ b/ak-py/src/agentkernel/knowledgebase/starburst.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from typing import Any, List, Mapping
 
 import trino
@@ -15,6 +16,10 @@ STARBURST_USER = os.getenv("STARBURST_USER", "")
 STARBURST_PASSWORD = os.getenv("STARBURST_PASSWORD", "")
 STARBURST_PORT = int(os.getenv("STARBURST_PORT", "443"))
 
+# Match a real LIMIT clause: the keyword as its own token, followed by its required count.
+# A bare `"LIMIT" in sql` also matched identifiers like `credit_limits`, incorrectly skipping
+# the fallback and exposing the whole table; requiring the count also excludes columns/string literals.
+LIMIT_CLAUSE = re.compile(r"\bLIMIT\s+(?:\d+|ALL)\b", re.IGNORECASE)
 
 class StarburstManager(KnowledgeBase):
     """
@@ -170,8 +175,10 @@ class StarburstManager(KnowledgeBase):
             logger.error(f"[KB][{self.name}] Rejected non-read SQL: {sql[:80]}")
             return []
 
-        # Append a safe LIMIT if the agent omitted one for SELECT statements.
-        if verb == "SELECT" and "LIMIT" not in sql.upper():
+        # Append a safe LIMIT if the agent omitted one for SELECT statements. Any LIMIT
+        # token counts, wherever it sits: one in a subquery already bounds the result, and
+        # appending a second clause to a statement that has one would be invalid SQL.
+        if verb == "SELECT" and not LIMIT_CLAUSE.search(sql):
             sql = f"{sql} LIMIT {limit}"
 
         return self._execute(sql, retried=False)

--- a/ak-py/src/agentkernel/knowledgebase/starburst.py
+++ b/ak-py/src/agentkernel/knowledgebase/starburst.py
@@ -6,6 +6,8 @@ import trino
 import trino.exceptions
 
 from .base import KnowledgeBase
+from .errors import KnowledgeCapabilityError
+from .model import KnowledgeCapabilities
 
 logger = logging.getLogger("ak.StarburstManager")
 
@@ -57,14 +59,17 @@ class StarburstManager(KnowledgeBase):
         :param description: Optional human-readable backend description.
         :return: None.
         """
-        super().__init__()
+        super().__init__(
+            capabilities=KnowledgeCapabilities(kinds=["structured"], query=True, query_language="sql", writable=False),
+            name=name,
+        )
 
         self.host = host or STARBURST_HOST
         self.port = port or STARBURST_PORT
         self.user = user or STARBURST_USER
         self.password = password or STARBURST_PASSWORD
         self.catalog = catalog
-        self.schema = schema
+        self.db_schema = schema
         self.table_name = table_name
         self.name = name
         self.description = description or (f"Starburst Galaxy read-only backend. " f"Query target: {catalog}.{schema}.{table_name}")
@@ -108,12 +113,12 @@ class StarburstManager(KnowledgeBase):
             port=self.port,
             user=self.user,
             catalog=self.catalog or None,
-            schema=self.schema or None,
+            schema=self.db_schema or None,
             http_scheme="https",
             auth=trino.auth.BasicAuthentication(self.user, self.password),
             request_timeout=60,
         )
-        logger.info(f"[KB][{self.name}] Connected → {self.host} " f"| {self.catalog}.{self.schema}.{self.table_name}")
+        logger.info(f"[KB][{self.name}] Connected → {self.host} " f"| {self.catalog}.{self.db_schema}.{self.table_name}")
 
     def close(self) -> None:
         """
@@ -136,9 +141,9 @@ class StarburstManager(KnowledgeBase):
         :param records: Unused write payload.
         :param kwargs: Reserved for interface compatibility.
         :return: None.
-        :raises NotImplementedError: Always raised for this backend.
+        :raises KnowledgeCapabilityError: Always raised for this backend.
         """
-        raise NotImplementedError(f"[KB][{self.name}] StarburstManager is read-only.")
+        raise KnowledgeCapabilityError(self.backend_name, "write")
 
     def get_description(self) -> str:
         """
@@ -148,7 +153,7 @@ class StarburstManager(KnowledgeBase):
         """
         return f"{self.backend_name}: {self.description}"
 
-    def read(self, query: str = "", limit: int = 5, **kwargs) -> List[Mapping[str, Any]]:
+    def query(self, statement: str = "", limit: int = 3, **kwargs) -> List[Mapping[str, Any]]:
         """
         Execute a validated read-only SQL query against Starburst Galaxy.
 
@@ -156,29 +161,29 @@ class StarburstManager(KnowledgeBase):
         ``DESCRIBE``. If no ``LIMIT`` clause is present, a safe fallback limit is
         appended before execution.
 
-        :param query: Agent-generated SQL statement.
+        :param statement: Agent-generated SQL statement.
         :param limit: Fallback row limit applied when SQL has no LIMIT clause.
         :param kwargs: Reserved for interface compatibility.
         :return: Normalized list of records with ``text`` and ``metadata`` keys.
         """
-        if not query or not query.strip():
+        if not statement or not statement.strip():
             logger.warning(f"[KB][{self.name}] Empty query received.")
             return []
 
-        sql = query.strip().rstrip(";")
+        sql = statement.strip().rstrip(";")
         if not sql:
             logger.warning(f"[KB][{self.name}] Empty query after normalization.")
             return []
 
-        statement = sql.upper().split()[0]
+        verb = sql.upper().split()[0]
 
         # Only allow read-safe statements
-        if statement not in ("SELECT", "SHOW", "DESCRIBE"):
+        if verb not in ("SELECT", "SHOW", "DESCRIBE"):
             logger.error(f"[KB][{self.name}] Rejected non-read SQL: {sql[:80]}")
             return []
 
         # Append a safe LIMIT if the agent omitted one for SELECT statements.
-        if statement == "SELECT" and "LIMIT" not in sql.upper():
+        if verb == "SELECT" and "LIMIT" not in sql.upper():
             sql = f"{sql} LIMIT {limit}"
 
         return self._execute(sql, retried=False)
@@ -201,7 +206,7 @@ class StarburstManager(KnowledgeBase):
 
             columns = [desc[0] for desc in cursor.description]
             rows = cursor.fetchall()
-            source = f"{self.catalog}.{self.schema}.{self.table_name}"
+            source = f"{self.catalog}.{self.db_schema}.{self.table_name}"
 
             results = [
                 {

--- a/ak-py/tests/test_knowledgebase_backends.py
+++ b/ak-py/tests/test_knowledgebase_backends.py
@@ -12,7 +12,7 @@ from typing import Any, Mapping
 import pytest
 
 from agentkernel.knowledgebase.chroma import ChromaManager
-from agentkernel.knowledgebase.errors import KnowledgeCapabilityError
+from agentkernel.knowledgebase.errors import KnowledgeCapabilityError, KnowledgeError
 from agentkernel.knowledgebase.neo4j import Neo4jManager
 from agentkernel.knowledgebase.starburst import StarburstManager
 
@@ -191,16 +191,36 @@ class TestNeo4jManager:
 
     def test_a_record_carrying_no_query_is_skipped_rather_than_executed(self, neo4j, neo4j_driver):
         # It used to reach the driver as _run(None, {}).
-        neo4j.write([{"text": "just prose", "metadata": {"source": "agent"}}])
+        with pytest.raises(KnowledgeError):
+            neo4j.write([{"text": "just prose", "metadata": {"source": "agent"}}])
         assert neo4j_driver.executed == []
 
     def test_a_skipped_record_does_not_stop_the_rest_of_the_batch(self, neo4j, neo4j_driver):
-        neo4j.write(
-            [
-                {"text": "just prose", "metadata": {"source": "agent"}},
-                {"text": "", "metadata": {"query": "CREATE (:N)"}},
-            ]
-        )
+        with pytest.raises(KnowledgeError):
+            neo4j.write(
+                [
+                    {"text": "just prose", "metadata": {"source": "agent"}},
+                    {"text": "", "metadata": {"query": "CREATE (:N)"}},
+                ]
+            )
+        # Raised only once the batch was through, so the healthy record still landed.
+        assert neo4j_driver.executed == [("CREATE (:N)", {})]
+
+    def test_the_skip_report_names_what_was_stored_and_what_was_not(self, neo4j, neo4j_driver):
+        # write_kb turns this into "Failed to write...", which is the whole point: a
+        # text-only write to Neo4j used to be reported to the agent as a success.
+        with pytest.raises(KnowledgeError) as excinfo:
+            neo4j.write(
+                [
+                    {"text": "just prose", "metadata": {"source": "agent"}},
+                    {"text": "", "metadata": {"query": "CREATE (:N)"}},
+                ]
+            )
+        assert "1 of 2" in str(excinfo.value)
+        assert "1 stored" in str(excinfo.value)
+
+    def test_a_batch_that_is_entirely_writable_does_not_report(self, neo4j, neo4j_driver):
+        neo4j.write([{"text": "", "metadata": {"query": "CREATE (:N)"}}])
         assert neo4j_driver.executed == [("CREATE (:N)", {})]
 
     def test_schema_carries_the_declaration(self, neo4j):
@@ -259,6 +279,6 @@ class TestStarburstManager:
         assert excinfo.value.subject == "starburst"
         assert excinfo.value.capability == "write"
 
-    def test_write_with_no_arguments_also_raises_the_capability_error(self, starburst):
-        with pytest.raises(KnowledgeCapabilityError):
-            starburst.write()
+    def test_write_is_refused_by_the_base_declaration_not_by_an_override(self, starburst):
+        # StarburstManager no longer overrides write(); writable=False is what refuses it.
+        assert "write" not in vars(type(starburst))

--- a/ak-py/tests/test_knowledgebase_backends.py
+++ b/ak-py/tests/test_knowledgebase_backends.py
@@ -269,6 +269,39 @@ class TestStarburstManager:
         starburst.query("SELECT * FROM orders")
         assert starburst.connection.cursors[0].executed == ["SELECT * FROM orders LIMIT 3"]
 
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            # The bug: "LIMIT" in sql.upper() matched inside the identifier, so the whole
+            # table was read into the agent's context unbounded.
+            "SELECT * FROM credit_limits",
+            "SELECT rate_limit FROM policies",
+            # A word boundary alone still matches these two, which is why the clause has
+            # to carry its count to count.
+            "SELECT * FROM t WHERE note = 'limit'",
+            "SELECT limit FROM policies",
+        ],
+    )
+    def test_an_identifier_containing_limit_does_not_disable_the_fallback(self, starburst, sql: str):
+        starburst.query(sql)
+        assert starburst.connection.cursors[0].executed == [f"{sql} LIMIT 3"]
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT * FROM orders LIMIT 10",
+            "select * from orders limit 10",
+            # A subquery LIMIT already bounds the result, and appending a second clause
+            # to a statement that has one would be invalid SQL.
+            "SELECT * FROM (SELECT * FROM orders LIMIT 10) t",
+            "SELECT * FROM t LIMIT ALL",
+            "SELECT * FROM orders OFFSET 5 LIMIT 10",
+        ],
+    )
+    def test_a_statement_that_already_bounds_itself_is_left_alone(self, starburst, sql: str):
+        starburst.query(sql)
+        assert starburst.connection.cursors[0].executed == [sql]
+
     def test_non_read_sql_is_still_rejected(self, starburst):
         assert starburst.query("DELETE FROM orders") == []
         assert starburst.connection.cursors == []

--- a/ak-py/tests/test_knowledgebase_backends.py
+++ b/ak-py/tests/test_knowledgebase_backends.py
@@ -1,0 +1,264 @@
+"""Capability declarations and renamed operations on the three shipped backends (#553 iteration 2).
+
+Every backend SDK is faked — no test touches a live Chroma, Neo4j, or Starburst. What is
+pinned here is the part of the refactor that is invisible until something calls it: the
+declarations, the read -> search/query renames, the new limit defaults, Neo4j's generic
+write metadata, and the StarburstManager.schema attribute/method collision, which made
+get_schemas raise TypeError for every Starburst deployment.
+"""
+
+from typing import Any, Mapping
+
+import pytest
+
+from agentkernel.knowledgebase.chroma import ChromaManager
+from agentkernel.knowledgebase.errors import KnowledgeCapabilityError
+from agentkernel.knowledgebase.neo4j import Neo4jManager
+from agentkernel.knowledgebase.starburst import StarburstManager
+
+
+class FakeChromaCollection:
+    def __init__(self) -> None:
+        self.queries: list[tuple[list[str], int]] = []
+        self.upserts: list[dict] = []
+
+    def query(self, query_texts, n_results):
+        self.queries.append((query_texts, n_results))
+        return {"documents": [["doc one"]], "metadatas": [[{"source": "kb"}]]}
+
+    def upsert(self, documents, metadatas, ids):
+        self.upserts.append({"documents": documents, "metadatas": metadatas, "ids": ids})
+
+
+class FakeChromaClient:
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.collection = FakeChromaCollection()
+
+    def get_or_create_collection(self, name, embedding_function):
+        return self.collection
+
+
+class FakeNeo4jRecord:
+    def __init__(self, payload: Mapping[str, Any]) -> None:
+        self.payload = payload
+
+    def data(self):
+        return dict(self.payload)
+
+
+class FakeNeo4jDriver:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, dict]] = []
+        self.closed = False
+
+    def verify_connectivity(self) -> None:
+        pass
+
+    def execute_query(self, query, parameters_=None, database_=None):
+        self.executed.append((query, dict(parameters_ or {})))
+        return [FakeNeo4jRecord({"n": 1})], None, None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeTrinoCursor:
+    description = [("col",)]
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    def execute(self, sql: str) -> None:
+        self.executed.append(sql)
+
+    def fetchall(self):
+        return [("value",)]
+
+    def close(self) -> None:
+        pass
+
+
+class FakeTrinoConnection:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.cursors: list[FakeTrinoCursor] = []
+
+    def cursor(self) -> FakeTrinoCursor:
+        created = FakeTrinoCursor()
+        self.cursors.append(created)
+        return created
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def chroma(monkeypatch) -> ChromaManager:
+    monkeypatch.setattr("agentkernel.knowledgebase.chroma.chromadb.PersistentClient", FakeChromaClient)
+    # Passing an embedding function keeps DefaultEmbeddingFunction (and its model download) out.
+    return ChromaManager(persist_path="/tmp/unused-chroma", embedding_function=object())
+
+
+@pytest.fixture
+def neo4j_driver() -> FakeNeo4jDriver:
+    return FakeNeo4jDriver()
+
+
+@pytest.fixture
+def neo4j(monkeypatch, neo4j_driver) -> Neo4jManager:
+    class FakeGraphDatabase:
+        @staticmethod
+        def driver(uri, auth=None):
+            return neo4j_driver
+
+    monkeypatch.setattr("agentkernel.knowledgebase.neo4j.GraphDatabase", FakeGraphDatabase)
+    return Neo4jManager(uri="bolt://fake:7687", user="neo4j", password="secret")
+
+
+@pytest.fixture
+def starburst(monkeypatch) -> StarburstManager:
+    monkeypatch.setattr("trino.dbapi.connect", lambda **kwargs: FakeTrinoConnection(**kwargs))
+    monkeypatch.setattr("trino.auth.BasicAuthentication", lambda user, password: ("auth", user))
+    return StarburstManager(
+        host="fake.galaxy",
+        user="u",
+        password="p",
+        catalog="mongo",
+        schema="sales",
+        table_name="orders",
+    )
+
+
+class TestChromaManager:
+    def test_it_declares_semantic_search_and_writes(self, chroma):
+        caps = chroma.capabilities
+        assert caps.kinds == ["vector"]
+        assert (caps.search, caps.search_mode, caps.writable) == (True, "semantic", True)
+        assert (caps.query, caps.fetch, caps.browse, caps.derives_schema) == (False, False, False, False)
+
+    def test_relevance_retrieval_is_now_named_search(self, chroma):
+        assert "search" in ChromaManager.__dict__
+        assert "read" not in ChromaManager.__dict__  # inherited and routing, no longer overridden
+        assert chroma.search("refund policy") == [{"text": "doc one", "metadata": {"source": "kb"}}]
+
+    def test_read_routes_to_search(self, chroma):
+        chroma.read("refund policy", limit=7)
+        assert chroma.collection.queries == [(["refund policy"], 7)]
+
+    def test_writes_still_reach_the_collection(self, chroma):
+        chroma.write([{"text": "a fact", "metadata": {"source": "kb"}}])
+        assert chroma.collection.upserts[0]["documents"] == ["a fact"]
+
+    def test_schema_carries_the_declaration(self, chroma):
+        schema = chroma.add_schema({"description": "vectors"}).schema()
+        assert schema["capabilities"]["search_mode"] == "semantic"
+
+
+class TestNeo4jManager:
+    def test_it_declares_cypher_query_and_writes(self, neo4j):
+        caps = neo4j.capabilities
+        assert caps.kinds == ["graph", "structured"]
+        assert (caps.query, caps.query_language, caps.writable) == (True, "cypher", True)
+        assert (caps.search, caps.fetch, caps.browse) == (False, False, False)
+
+    def test_query_language_retrieval_is_now_named_query(self, neo4j):
+        assert "query" in Neo4jManager.__dict__
+        assert "read" not in Neo4jManager.__dict__
+        rows = neo4j.query("MATCH (n) RETURN n")
+        assert rows == [{"text": '{"n": 1}', "metadata": {"source": "graph"}}]
+
+    def test_read_routes_to_query(self, neo4j, neo4j_driver):
+        neo4j.read("MATCH (n) RETURN n")
+        assert "MATCH (n) RETURN n" in neo4j_driver.executed[0][0]
+
+    def test_query_defaults_to_a_limit_of_three(self, neo4j, neo4j_driver):
+        neo4j.query("MATCH (n) RETURN n")
+        assert neo4j_driver.executed[0][1] == {"ak_read_limit": 3}
+
+    def test_write_prefers_the_generic_query_key(self, neo4j, neo4j_driver):
+        neo4j.write([{"text": "", "metadata": {"query": "CREATE (:N)", "params": {"a": 1}}}])
+        assert neo4j_driver.executed == [("CREATE (:N)", {"a": 1})]
+
+    def test_write_falls_back_to_the_legacy_cypher_keys(self, neo4j, neo4j_driver):
+        neo4j.write([{"text": "", "metadata": {"cypher_query": "CREATE (:Old)", "cypher_params": {"b": 2}}}])
+        assert neo4j_driver.executed == [("CREATE (:Old)", {"b": 2})]
+
+    def test_the_generic_key_wins_when_both_are_present(self, neo4j, neo4j_driver):
+        metadata = {"query": "CREATE (:New)", "cypher_query": "CREATE (:Old)"}
+        neo4j.write([{"text": "", "metadata": metadata}])
+        assert neo4j_driver.executed == [("CREATE (:New)", {})]
+
+    def test_a_record_carrying_no_query_is_skipped_rather_than_executed(self, neo4j, neo4j_driver):
+        # It used to reach the driver as _run(None, {}).
+        neo4j.write([{"text": "just prose", "metadata": {"source": "agent"}}])
+        assert neo4j_driver.executed == []
+
+    def test_a_skipped_record_does_not_stop_the_rest_of_the_batch(self, neo4j, neo4j_driver):
+        neo4j.write(
+            [
+                {"text": "just prose", "metadata": {"source": "agent"}},
+                {"text": "", "metadata": {"query": "CREATE (:N)"}},
+            ]
+        )
+        assert neo4j_driver.executed == [("CREATE (:N)", {})]
+
+    def test_schema_carries_the_declaration(self, neo4j):
+        schema = neo4j.add_schema({"nodes": ["Customer"]}).schema()
+        assert schema["capabilities"]["query_language"] == "cypher"
+
+
+class TestStarburstManager:
+    def test_it_declares_read_only_sql(self, starburst):
+        caps = starburst.capabilities
+        assert caps.kinds == ["structured"]
+        assert (caps.query, caps.query_language, caps.writable) == (True, "sql", False)
+        assert (caps.search, caps.fetch, caps.browse) == (False, False, False)
+
+    def test_the_trino_schema_now_lives_on_db_schema(self, starburst):
+        assert starburst.db_schema == "sales"
+
+    def test_schema_resolves_to_the_inherited_method(self, starburst):
+        # The regression guard: self.schema used to shadow schema(), so get_schemas raised
+        # TypeError: 'str' object is not callable for every Starburst deployment.
+        assert callable(starburst.schema)
+        result = starburst.add_schema({"table": "mongo.sales.orders"}).schema()
+        assert isinstance(result, Mapping)
+        assert result["table"] == "mongo.sales.orders"
+        assert result["capabilities"]["query_language"] == "sql"
+
+    def test_the_schema_constructor_keyword_is_unchanged(self, starburst):
+        # Both shipped examples pass schema=..., so the keyword must keep working.
+        assert starburst.connection.kwargs["schema"] == "sales"
+        assert starburst.connection.kwargs["catalog"] == "mongo"
+
+    def test_the_row_source_uses_the_renamed_attribute(self, starburst):
+        rows = starburst.query("SELECT * FROM orders")
+        assert rows == [{"text": "col: value", "metadata": {"source": "mongo.sales.orders"}}]
+
+    def test_query_language_retrieval_is_now_named_query(self, starburst):
+        assert "query" in StarburstManager.__dict__
+        assert "read" not in StarburstManager.__dict__
+        assert starburst.query("SELECT 1") == [{"text": "col: value", "metadata": {"source": "mongo.sales.orders"}}]
+
+    def test_read_routes_to_query(self, starburst):
+        starburst.read("SELECT * FROM orders")
+        assert starburst.connection.cursors[0].executed == ["SELECT * FROM orders LIMIT 3"]
+
+    def test_query_defaults_to_a_limit_of_three(self, starburst):
+        starburst.query("SELECT * FROM orders")
+        assert starburst.connection.cursors[0].executed == ["SELECT * FROM orders LIMIT 3"]
+
+    def test_non_read_sql_is_still_rejected(self, starburst):
+        assert starburst.query("DELETE FROM orders") == []
+        assert starburst.connection.cursors == []
+
+    def test_write_raises_a_capability_error(self, starburst):
+        with pytest.raises(KnowledgeCapabilityError) as excinfo:
+            starburst.write([{"text": "x"}])
+        assert excinfo.value.subject == "starburst"
+        assert excinfo.value.capability == "write"
+
+    def test_write_with_no_arguments_also_raises_the_capability_error(self, starburst):
+        with pytest.raises(KnowledgeCapabilityError):
+            starburst.write()

--- a/ak-py/tests/test_knowledgebase_base.py
+++ b/ak-py/tests/test_knowledgebase_base.py
@@ -1,0 +1,236 @@
+"""The reshaped KnowledgeBase ABC (#553 iteration 2).
+
+Three things here are the contract every backend depends on and are easy to break silently:
+read() routing on the declaration, an undeclared operation raising rather than returning
+empty, and schema() precedence — where capabilities must be the one key a deployment cannot
+contradict through add_schema().
+
+Backends are declared inline rather than through a shared fixture; the reusable
+FakeKnowledgeBase lands with KnowledgeBaseContract.
+"""
+
+from typing import Any, List, Mapping
+
+import pytest
+
+from agentkernel.knowledgebase.base import KnowledgeBase, Record
+from agentkernel.knowledgebase.errors import KnowledgeCapabilityError
+from agentkernel.knowledgebase.model import KnowledgeCapabilities
+
+
+class MinimalBackend(KnowledgeBase):
+    """Implements only the three members that stayed abstract."""
+
+    def __init__(self, capabilities: KnowledgeCapabilities, name: str | None = None) -> None:
+        super().__init__(capabilities=capabilities, name=name)
+        self.calls: list[tuple[str, tuple, dict]] = []
+
+    @property
+    def backend_name(self) -> str:
+        return "minimal"
+
+    def connect(self, **kwargs) -> None:
+        pass
+
+    def get_description(self) -> str:
+        return "minimal: a backend with nothing but the required surface"
+
+
+class RecordingBackend(MinimalBackend):
+    """Records which operation was reached, so routing is observable."""
+
+    def search(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
+        self.calls.append(("search", (query, limit), kwargs))
+        return [{"text": f"search:{query}", "metadata": {}}]
+
+    def query(self, statement: str, limit: int = 3, **kwargs) -> List[Record]:
+        self.calls.append(("query", (statement, limit), kwargs))
+        return [{"text": f"query:{statement}", "metadata": {}}]
+
+
+def _searcher() -> RecordingBackend:
+    return RecordingBackend(KnowledgeCapabilities(kinds=["vector"], search=True))
+
+
+def _querier() -> RecordingBackend:
+    return RecordingBackend(KnowledgeCapabilities(kinds=["structured"], query=True, query_language="sql"))
+
+
+class TestConstruction:
+    def test_the_class_name_is_the_validation_subject_when_name_is_omitted(self):
+        with pytest.raises(ValueError, match="'MinimalBackend'"):
+            MinimalBackend(KnowledgeCapabilities())
+
+    def test_a_given_name_is_the_validation_subject(self):
+        with pytest.raises(ValueError, match="'my-kb'"):
+            MinimalBackend(KnowledgeCapabilities(), name="my-kb")
+
+    def test_a_query_incoherent_declaration_is_refused_at_construction(self):
+        with pytest.raises(ValueError, match="without a query_language"):
+            MinimalBackend(KnowledgeCapabilities(query=True))
+
+    def test_the_declaration_is_kept_on_the_instance(self):
+        backend = _searcher()
+        assert backend.capabilities.search is True
+        assert backend.capabilities.kinds == ["vector"]
+
+    def test_only_three_members_stay_abstract(self):
+        assert set(KnowledgeBase.__abstractmethods__) == {"backend_name", "connect", "get_description"}
+
+    def test_a_backend_implementing_neither_read_nor_write_constructs(self):
+        # read and write stopped being abstract, so the required surface is three members.
+        backend = MinimalBackend(KnowledgeCapabilities(browse=True))
+        assert backend.get_description().startswith("minimal:")
+
+
+class TestReadRouting:
+    def test_read_routes_to_query_for_a_query_backend(self):
+        backend = _querier()
+        assert backend.read("SELECT 1") == [{"text": "query:SELECT 1", "metadata": {}}]
+        assert backend.calls[0][0] == "query"
+
+    def test_read_routes_to_search_for_a_non_query_backend(self):
+        backend = _searcher()
+        assert backend.read("refund policy") == [{"text": "search:refund policy", "metadata": {}}]
+        assert backend.calls[0][0] == "search"
+
+    def test_read_forwards_limit_and_kwargs_unchanged(self):
+        backend = _querier()
+        backend.read("SELECT 1", limit=17, where="x", flag=True)
+        operation, positional, kwargs = backend.calls[0]
+        assert operation == "query"
+        assert positional == ("SELECT 1", 17)
+        assert kwargs == {"where": "x", "flag": True}
+
+    def test_read_defaults_to_a_limit_of_three(self):
+        backend = _searcher()
+        backend.read("anything")
+        assert backend.calls[0][1] == ("anything", 3)
+
+    def test_a_subclass_overriding_read_still_wins(self):
+        class OverridingBackend(RecordingBackend):
+            def read(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
+                return [{"text": "override", "metadata": {}}]
+
+        backend = OverridingBackend(KnowledgeCapabilities(query=True, query_language="sql"))
+        assert backend.read("SELECT 1") == [{"text": "override", "metadata": {}}]
+        assert backend.calls == []
+
+
+class TestUndeclaredOperations:
+    @pytest.mark.parametrize(
+        "operation, call",
+        [
+            ("search", lambda b: b.search("q")),
+            ("query", lambda b: b.query("SELECT 1")),
+            ("fetch", lambda b: b.fetch(["a"])),
+            ("browse", lambda b: b.browse("")),
+            ("write", lambda b: b.write([{"text": "x"}])),
+        ],
+    )
+    def test_an_undeclared_operation_names_the_backend_and_the_operation(self, operation, call):
+        backend = MinimalBackend(KnowledgeCapabilities(browse=True))
+        with pytest.raises(KnowledgeCapabilityError) as excinfo:
+            call(backend)
+        assert excinfo.value.subject == "minimal"
+        assert excinfo.value.capability == operation
+        assert str(excinfo.value) == f"minimal does not support capability: {operation}"
+
+    def test_an_undeclared_operation_raises_rather_than_returning_empty(self):
+        # The distinction matters: an empty list means "nothing matched", not "unsupported".
+        backend = MinimalBackend(KnowledgeCapabilities(search=True))
+        with pytest.raises(KnowledgeCapabilityError):
+            backend.fetch(["a"])
+
+    def test_a_declared_operation_a_backend_forgot_to_implement_still_raises(self):
+        # Declaration and implementation are only checked together by the contract suite,
+        # so the base must not silently pretend the operation exists.
+        backend = MinimalBackend(KnowledgeCapabilities(fetch=True))
+        with pytest.raises(KnowledgeCapabilityError, match="fetch"):
+            backend.fetch(["a"])
+
+
+class TestSchema:
+    def test_no_schema_from_either_source_raises_the_unchanged_message(self):
+        backend = _searcher()
+        with pytest.raises(ValueError) as excinfo:
+            backend.schema()
+        assert str(excinfo.value) == "Schema for 'minimal' has not been set! Call .add_schema() before passing to the Agent."
+
+    def test_add_schema_alone_is_enough(self):
+        backend = _searcher()
+        schema = backend.add_schema({"tables": ["orders"]}).schema()
+        assert schema["tables"] == ["orders"]
+        assert schema["backend"] == "minimal"
+
+    def test_a_derived_schema_alone_no_longer_raises(self):
+        class DerivingBackend(MinimalBackend):
+            def _derived_schema(self) -> Mapping[str, Any]:
+                return {"concepts": 4}
+
+        schema = DerivingBackend(KnowledgeCapabilities(browse=True, derives_schema=True)).schema()
+        assert schema["concepts"] == 4
+
+    def test_add_schema_beats_the_derived_schema(self):
+        class DerivingBackend(MinimalBackend):
+            def _derived_schema(self) -> Mapping[str, Any]:
+                return {"concepts": 4, "kept": "yes"}
+
+        backend = DerivingBackend(KnowledgeCapabilities(browse=True, derives_schema=True))
+        schema = backend.add_schema({"concepts": 99}).schema()
+        assert schema["concepts"] == 99
+        assert schema["kept"] == "yes"
+
+    def test_backend_stays_overridable_through_add_schema(self):
+        backend = _searcher()
+        assert backend.add_schema({"backend": "renamed"}).schema()["backend"] == "renamed"
+
+    def test_capabilities_is_not_overridable_through_add_schema(self):
+        # capabilities is what the tool layer routes on; a deployment must not contradict it.
+        backend = _searcher()
+        schema = backend.add_schema({"capabilities": {"search": False, "fetch": True}}).schema()
+        assert schema["capabilities"] == backend.capabilities.model_dump()
+        assert schema["capabilities"]["search"] is True
+        assert schema["capabilities"]["fetch"] is False
+
+    def test_schema_always_carries_the_declaration(self):
+        schema = _querier().add_schema({"tables": ["orders"]}).schema()
+        assert schema["capabilities"]["query"] is True
+        assert schema["capabilities"]["query_language"] == "sql"
+
+    def test_neither_backend_nor_capabilities_counts_as_content_for_the_guard(self):
+        # An empty add_schema must not satisfy the guard just because two keys get added later.
+        backend = _searcher()
+        with pytest.raises(ValueError, match="has not been set"):
+            backend.add_schema({}).schema()
+
+
+class TestFormatResults:
+    def test_no_rows_returns_the_sentinel(self):
+        assert _searcher().format_results([]) == "No relevant knowledge found."
+
+    def test_a_non_fetch_backend_renders_the_unprefixed_line(self):
+        rows = [{"text": "hello", "metadata": {"source": "docs", "id": "a/b.md"}}]
+        assert _searcher().format_results(rows) == "- hello (source: docs)"
+
+    def test_a_missing_source_falls_back_to_na(self):
+        assert _searcher().format_results([{"text": "hello"}]) == "- hello (source: N/A)"
+
+    def test_a_fetch_backend_prefixes_the_record_id(self):
+        backend = MinimalBackend(KnowledgeCapabilities(fetch=True))
+        rows = [{"text": "hello", "metadata": {"source": "docs", "id": "a/b.md"}}]
+        assert backend.format_results(rows) == "- [a/b.md] hello (source: docs)"
+
+    @pytest.mark.parametrize("record_id", [None, "", 42, ["a"]])
+    def test_an_unusable_id_degrades_to_the_unprefixed_line(self, record_id):
+        backend = MinimalBackend(KnowledgeCapabilities(fetch=True))
+        rows = [{"text": "hello", "metadata": {"source": "docs", "id": record_id}}]
+        assert backend.format_results(rows) == "- hello (source: docs)"
+
+    def test_a_null_metadata_value_is_tolerated(self):
+        backend = MinimalBackend(KnowledgeCapabilities(fetch=True))
+        assert backend.format_results([{"text": "hello", "metadata": None}]) == "- hello (source: N/A)"
+
+    def test_every_row_gets_its_own_line(self):
+        rows = [{"text": "one", "metadata": {"source": "a"}}, {"text": "two", "metadata": {"source": "b"}}]
+        assert _searcher().format_results(rows) == "- one (source: a)\n- two (source: b)"

--- a/ak-py/tests/test_knowledgebase_builder.py
+++ b/ak-py/tests/test_knowledgebase_builder.py
@@ -170,6 +170,32 @@ class TestRouting:
         # The gate, not the backend, is what stopped the call.
         assert vector.calls == []
 
+    def test_read_kb_at_a_backend_that_can_neither_search_nor_query_names_the_right_tools(self):
+        # read() would have fallen through to search() and reported a capability the agent
+        # never asked for; nothing here can serve a read, so the alternatives list is empty.
+        identities = StubBackend(KnowledgeCapabilities(kinds=["document"], fetch=True), name="ids")
+        read_kb = _tool(KnowledgeBuilder([identities]), "read_kb")
+
+        assert read_kb("ids", "anything") == "Backend 'ids' does not support reads. Backends that do: []."
+        assert identities.calls == []
+
+    def test_read_kb_points_at_the_backends_that_can_serve_a_read(self):
+        identities = StubBackend(KnowledgeCapabilities(kinds=["document"], fetch=True), name="ids")
+        builder = KnowledgeBuilder([identities, _vector(), _sql()])
+
+        result = _tool(builder, "read_kb")("ids", "anything")
+
+        # Both a search backend and a query backend satisfy a read.
+        assert result == "Backend 'ids' does not support reads. Backends that do: ['vector', 'sql']."
+
+    def test_write_kb_at_a_read_only_backend_is_gated_rather_than_raised_through(self):
+        sql = _sql()
+        result = _tool(KnowledgeBuilder([sql, _vector()]), "write_kb")("sql", text="an order")
+
+        # The field is spelled "writable"; the agent is told "writes".
+        assert result == "Backend 'sql' does not support writes. Backends that do: ['vector']."
+        assert sql.written == []
+
     def test_an_unknown_backend_keeps_the_existing_message(self):
         builder = KnowledgeBuilder([_documents()])
         assert _tool(builder, "browse_kb")("nope") == "Unknown backend 'nope'. Available: ['okf']"

--- a/ak-py/tests/test_knowledgebase_builder.py
+++ b/ak-py/tests/test_knowledgebase_builder.py
@@ -1,0 +1,326 @@
+"""Capability-gated agent tools on KnowledgeBuilder (#553 iteration 3).
+
+This is the riskiest consumer of the capability model: everything here is prompt-visible,
+so a wrong gate silently changes what every agent in a deployment can see. What is pinned
+is the gating matrix over the registered set, the tool order (stable across runs so prompt
+caches stay warm), the mis-routing strings that must never become exceptions inside a
+framework, and write_kb's move off the Neo4j-specific cypher_* metadata keys.
+
+Backends are declared inline; the reusable FakeKnowledgeBase lands with KnowledgeBaseContract.
+"""
+
+import json
+import logging
+from typing import Iterable, List
+
+import pytest
+
+from agentkernel.knowledgebase.base import KnowledgeBase, Record
+from agentkernel.knowledgebase.knowledgebuilder import KnowledgeBuilder
+from agentkernel.knowledgebase.model import KnowledgeCapabilities
+
+BASE_TOOLS = ["get_schemas", "read_kb", "write_kb", "get_all_kb_descriptions"]
+
+
+class MinimalStub(KnowledgeBase):
+    """Implements only the three members that stayed abstract, so any operation raises."""
+
+    def __init__(self, capabilities: KnowledgeCapabilities, name: str = "stub") -> None:
+        super().__init__(capabilities=capabilities, name=name)
+        self.name = name
+        self.calls: list[tuple[str, tuple, dict]] = []
+        self.written: list[Record] = []
+
+    @property
+    def backend_name(self) -> str:
+        return self.name
+
+    def connect(self, **kwargs) -> None:
+        pass
+
+    def get_description(self) -> str:
+        return f"{self.name}: a stub backend"
+
+
+class StubBackend(MinimalStub):
+    """Records which operation was reached and with what, so routing is observable."""
+
+    def search(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
+        self.calls.append(("search", (query, limit), kwargs))
+        return [{"text": f"search:{query}", "metadata": {"source": self.name}}]
+
+    def query(self, statement: str, limit: int = 3, **kwargs) -> List[Record]:
+        self.calls.append(("query", (statement, limit), kwargs))
+        return [{"text": f"query:{statement}", "metadata": {"source": self.name}}]
+
+    def fetch(self, ids: List[str], **kwargs) -> List[Record]:
+        self.calls.append(("fetch", (list(ids),), kwargs))
+        return [{"text": f"fetch:{identity}", "metadata": {"source": self.name}} for identity in ids]
+
+    def browse(self, path: str = "", limit: int = 50, **kwargs) -> List[Record]:
+        self.calls.append(("browse", (path, limit), kwargs))
+        return [{"text": f"browse:{path}", "metadata": {"source": self.name}}]
+
+    def write(self, records: Iterable[Record], **kwargs) -> None:
+        self.written.extend(records)
+
+
+class NoCapabilitiesBackend(KnowledgeBase):
+    """A backend whose __init__ never calls super().__init__(), so it has no declaration."""
+
+    def __init__(self, name: str = "undeclared") -> None:
+        self.name = name
+
+    @property
+    def backend_name(self) -> str:
+        return self.name
+
+    def connect(self, **kwargs) -> None:
+        pass
+
+    def get_description(self) -> str:
+        return f"{self.name}: never declared anything"
+
+
+def _vector(name: str = "vector") -> StubBackend:
+    """The ChromaManager shape."""
+    return StubBackend(KnowledgeCapabilities(kinds=["vector"], search=True, search_mode="semantic", writable=True), name=name)
+
+
+def _sql(name: str = "sql") -> StubBackend:
+    """The StarburstManager shape."""
+    return StubBackend(KnowledgeCapabilities(kinds=["structured"], query=True, query_language="sql"), name=name)
+
+
+def _documents(name: str = "okf") -> StubBackend:
+    """The OKFManager shape: relevance, identity, and enumeration over documents."""
+    return StubBackend(KnowledgeCapabilities(kinds=["document"], search=True, fetch=True, browse=True, writable=True), name=name)
+
+
+def _tool_names(builder: KnowledgeBuilder) -> List[str]:
+    return [tool.__name__ for tool in builder.build()]
+
+
+def _tool(builder: KnowledgeBuilder, name: str):
+    for tool in builder.build():
+        if tool.__name__ == name:
+            return tool
+    raise AssertionError(f"{name} was not emitted; got {_tool_names(builder)}")
+
+
+class TestToolGating:
+    def test_a_vector_only_application_gets_exactly_the_four_existing_tools(self):
+        # The compatibility promise: adding the capability model must not change the prompt
+        # of an application that was already working.
+        assert _tool_names(KnowledgeBuilder([_vector()])) == BASE_TOOLS
+
+    def test_a_query_only_application_gets_exactly_the_four_existing_tools(self):
+        assert _tool_names(KnowledgeBuilder([_sql()])) == BASE_TOOLS
+
+    def test_fetch_adds_only_fetch_kb(self):
+        backend = StubBackend(KnowledgeCapabilities(kinds=["document"], fetch=True), name="ids")
+        assert _tool_names(KnowledgeBuilder([backend])) == BASE_TOOLS + ["fetch_kb"]
+
+    def test_browse_adds_only_browse_kb(self):
+        backend = StubBackend(KnowledgeCapabilities(kinds=["document"], browse=True), name="tree")
+        assert _tool_names(KnowledgeBuilder([backend])) == BASE_TOOLS + ["browse_kb"]
+
+    def test_search_and_query_on_one_backend_emits_search_kb(self):
+        # read() routes to query() whenever query is declared, which would leave search()
+        # unreachable. search_kb is what makes the declaration honest.
+        backend = StubBackend(KnowledgeCapabilities(kinds=["hybrid"], search=True, query=True, query_language="sql"), name="hybrid")
+        assert _tool_names(KnowledgeBuilder([backend])) == BASE_TOOLS + ["search_kb"]
+
+    def test_search_and_query_on_different_backends_does_not_emit_search_kb(self):
+        # The vector backend's search() is already reachable through read_kb, and the SQL
+        # backend has no search() at all, so nothing here is unreachable.
+        assert _tool_names(KnowledgeBuilder([_vector(), _sql()])) == BASE_TOOLS
+
+    def test_the_full_capability_set_emits_seven_tools_in_a_fixed_order(self):
+        backend = StubBackend(
+            KnowledgeCapabilities(kinds=["document"], search=True, query=True, query_language="sql", fetch=True, browse=True, writable=True),
+            name="everything",
+        )
+        assert _tool_names(KnowledgeBuilder([backend])) == BASE_TOOLS + ["search_kb", "fetch_kb", "browse_kb"]
+
+    def test_gating_is_a_property_of_the_registered_set_not_of_one_backend(self):
+        # A vector backend registered alongside an OKF-shaped one gains browse_kb in the
+        # prompt, and routing it at the vector backend is what reports the mismatch.
+        assert _tool_names(KnowledgeBuilder([_vector(), _documents()])) == BASE_TOOLS + ["fetch_kb", "browse_kb"]
+
+    def test_a_backend_without_a_declaration_warns_and_is_treated_as_declaring_nothing(self, caplog):
+        builder = KnowledgeBuilder([NoCapabilitiesBackend(), _documents()])
+
+        with caplog.at_level(logging.WARNING, logger="ak.KnowledgeBuilder"):
+            names = [tool.__name__ for tool in builder.build()]
+
+        assert names == BASE_TOOLS + ["fetch_kb", "browse_kb"]
+        assert "undeclared" in caplog.text
+        assert "super().__init__" in caplog.text
+
+
+class TestRouting:
+    def test_routing_at_a_backend_that_does_not_declare_the_capability_returns_a_string(self):
+        vector, documents = _vector(), _documents()
+        fetch_kb = _tool(KnowledgeBuilder([vector, documents]), "fetch_kb")
+
+        result = fetch_kb("vector", "some-id")
+
+        assert result == "Backend 'vector' does not support fetch. Backends that do: ['okf']."
+        # The gate, not the backend, is what stopped the call.
+        assert vector.calls == []
+
+    def test_an_unknown_backend_keeps_the_existing_message(self):
+        builder = KnowledgeBuilder([_documents()])
+        assert _tool(builder, "browse_kb")("nope") == "Unknown backend 'nope'. Available: ['okf']"
+
+    def test_search_kb_routes_at_any_backend_declaring_search(self):
+        hybrid = StubBackend(KnowledgeCapabilities(search=True, query=True, query_language="sql"), name="hybrid")
+        vector = _vector()
+        search_kb = _tool(KnowledgeBuilder([hybrid, vector]), "search_kb")
+
+        # The gate was opened by hybrid, but vector declares search too, so it serves.
+        assert search_kb("vector", "invoices") == "- search:invoices (source: vector)"
+        assert vector.calls == [("search", ("invoices", 3), {})]
+
+    def test_browse_defaults_reach_the_backend_unchanged(self):
+        documents = _documents()
+        _tool(KnowledgeBuilder([documents]), "browse_kb")("okf", "tables/")
+
+        assert documents.calls == [("browse", ("tables/", 50), {})]
+
+    def test_a_declared_but_unimplemented_operation_surfaces_as_text_not_an_exception(self):
+        # A dishonest declaration is a backend bug, but it must not escape into the framework.
+        dishonest = MinimalStub(KnowledgeCapabilities(kinds=["document"], browse=True), name="dishonest")
+        result = _tool(KnowledgeBuilder([dishonest]), "browse_kb")("dishonest", "")
+
+        assert result.startswith("Execution Error:")
+        assert "browse" in result
+
+
+class TestFetchIds:
+    def test_ids_are_split_stripped_and_emptied_segments_dropped(self):
+        documents = _documents()
+        _tool(KnowledgeBuilder([documents]), "fetch_kb")("okf", " a.md , ,b.md ")
+
+        assert documents.calls == [("fetch", (["a.md", "b.md"],), {})]
+
+    def test_an_all_empty_argument_never_reaches_the_backend(self):
+        documents = _documents()
+        result = _tool(KnowledgeBuilder([documents]), "fetch_kb")("okf", " , ")
+
+        assert result == "Error: provide at least one id."
+        assert documents.calls == []
+
+    def test_a_single_id_needs_no_separator(self):
+        documents = _documents()
+        _tool(KnowledgeBuilder([documents]), "fetch_kb")("okf", "tables/orders.md")
+
+        assert documents.calls == [("fetch", (["tables/orders.md"],), {})]
+
+
+class TestSemanticMap:
+    def test_search_kb_queries_are_resolved(self):
+        hybrid = StubBackend(KnowledgeCapabilities(search=True, query=True, query_language="sql"), name="hybrid")
+        builder = KnowledgeBuilder([hybrid], semantic_map={"<ORDERS>": "analytics.sales.orders"})
+
+        _tool(builder, "search_kb")("hybrid", "rows in <ORDERS>")
+
+        assert hybrid.calls == [("search", ("rows in analytics.sales.orders", 3), {})]
+
+    def test_browse_kb_paths_are_resolved(self):
+        documents = _documents()
+        builder = KnowledgeBuilder([documents], semantic_map={"<BUNDLE>": "prod/kb"})
+
+        _tool(builder, "browse_kb")("okf", "<BUNDLE>/tables")
+
+        assert documents.calls == [("browse", ("prod/kb/tables", 50), {})]
+
+    def test_fetch_kb_resolves_each_segment_after_the_split(self):
+        documents = _documents()
+        builder = KnowledgeBuilder([documents], semantic_map={"<BUNDLE>": "prod/kb"})
+
+        _tool(builder, "fetch_kb")("okf", "<BUNDLE>/a.md, <BUNDLE>/b.md")
+
+        assert documents.calls == [("fetch", (["prod/kb/a.md", "prod/kb/b.md"],), {})]
+
+
+class TestWriteMetadata:
+    def test_a_write_with_a_query_emits_the_generic_keys_only(self):
+        vector = _vector()
+        write_kb = _tool(KnowledgeBuilder([vector]), "write_kb")
+
+        write_kb("vector", text="an order", query="CREATE (n:Order)", params_json='{"id": 7}')
+
+        metadata = vector.written[0]["metadata"]
+        assert metadata == {"source": "agent", "query": "CREATE (n:Order)", "params": {"id": 7}}
+        # Neo4j's spelling is gone: it was being written for every backend, vector stores included.
+        assert "cypher_query" not in metadata
+        assert "cypher_params" not in metadata
+
+    def test_a_text_only_write_carries_only_the_source(self):
+        vector = _vector()
+        _tool(KnowledgeBuilder([vector]), "write_kb")("vector", text="an order")
+
+        assert vector.written == [{"text": "an order", "metadata": {"source": "agent"}}]
+
+    def test_write_queries_are_still_resolved_through_the_semantic_map(self):
+        vector = _vector()
+        builder = KnowledgeBuilder([vector], semantic_map={"<ORDERS>": "analytics.sales.orders"})
+
+        _tool(builder, "write_kb")("vector", text="an order", query="INSERT INTO <ORDERS> VALUES (1)")
+
+        assert vector.written[0]["metadata"]["query"] == "INSERT INTO analytics.sales.orders VALUES (1)"
+
+    @pytest.mark.parametrize("params_json", ["not json", "[1, 2]", '"a string"'])
+    def test_a_non_object_params_json_keeps_its_existing_message(self, params_json: str):
+        vector = _vector()
+        result = _tool(KnowledgeBuilder([vector]), "write_kb")("vector", query="MATCH (n)", params_json=params_json)
+
+        assert result == "Error: params_json must be a valid JSON object string."
+        assert vector.written == []
+
+
+class TestGetSchemas:
+    def test_one_failing_backend_no_longer_fails_the_whole_call(self):
+        healthy = _vector("healthy").add_schema({"columns": ["id"]})
+        # No add_schema() and no derived schema, so schema() raises the base ValueError.
+        broken = _sql("broken")
+        get_schemas = _tool(KnowledgeBuilder([healthy, broken]), "get_schemas")
+
+        schemas = json.loads(get_schemas())
+
+        assert schemas["healthy"]["columns"] == ["id"]
+        assert "has not been set" in schemas["broken"]["error"]
+
+    def test_capabilities_reach_the_agent_through_the_schema(self):
+        get_schemas = _tool(KnowledgeBuilder([_documents().add_schema({"about": "docs"})]), "get_schemas")
+
+        capabilities = json.loads(get_schemas())["okf"]["capabilities"]
+
+        assert capabilities["fetch"] is True
+        assert capabilities["browse"] is True
+        assert capabilities["query"] is False
+
+
+class TestUnchangedSurface:
+    def test_the_constructor_signature_and_its_validation_are_unchanged(self):
+        with pytest.raises(ValueError, match="Duplicate knowledge base backend_name"):
+            KnowledgeBuilder([_vector("same"), _sql("same")])
+
+    def test_read_kb_still_routes_on_the_declaration(self):
+        vector, sql = _vector(), _sql()
+        read_kb = _tool(KnowledgeBuilder([vector, sql]), "read_kb")
+
+        assert read_kb("vector", "invoices") == "- search:invoices (source: vector)"
+        assert read_kb("sql", "SELECT 1") == "- query:SELECT 1 (source: sql)"
+
+    def test_get_all_kb_descriptions_is_untouched(self):
+        builder = KnowledgeBuilder([_vector(), _documents()])
+        assert _tool(builder, "get_all_kb_descriptions")() == "vector: a stub backend\nokf: a stub backend"
+
+    def test_every_tool_is_a_plain_callable_with_a_docstring(self):
+        # The docstrings are the agent-visible tool descriptions, not developer notes.
+        for tool in KnowledgeBuilder([_documents()]).build():
+            assert callable(tool)
+            assert tool.__doc__ and tool.__doc__.strip()

--- a/ak-py/tests/test_knowledgebase_model.py
+++ b/ak-py/tests/test_knowledgebase_model.py
@@ -1,0 +1,178 @@
+"""Capability declaration and error types of the knowledge-base tier (#553 iteration 1).
+
+KnowledgeCapabilities is what every backend declares and what KnowledgeBase routes on, so
+the defaults and the exact field set are pinned here — a backend that forgets a field must
+get the conservative answer (False), and a field added later must fail this file loudly.
+
+The deliberate absence of cross-field validation is also pinned: the reachability and
+query/query_language invariants belong to KnowledgeBase.validate_capabilities, called by
+KnowledgeBase.__init__ because only it knows the backend name — so an incoherent declaration
+must still *construct*, and be refused one layer up. Both halves are pinned here.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from agentkernel.knowledgebase.base import KnowledgeBase
+from agentkernel.knowledgebase.errors import KnowledgeCapabilityError, KnowledgeError, KnowledgePathError
+from agentkernel.knowledgebase.model import KnowledgeCapabilities, KnowledgeMetadata, KnowledgeRecord
+
+CAPABILITY_FIELDS = {
+    "kinds",
+    "search",
+    "search_mode",
+    "query",
+    "query_language",
+    "fetch",
+    "browse",
+    "writable",
+    "derives_schema",
+}
+
+
+class TestKnowledgeCapabilities:
+    def test_every_operation_defaults_to_unsupported(self):
+        caps = KnowledgeCapabilities()
+        assert caps.search is False
+        assert caps.query is False
+        assert caps.fetch is False
+        assert caps.browse is False
+        assert caps.writable is False
+        assert caps.derives_schema is False
+
+    def test_advisory_fields_default_to_unstated(self):
+        caps = KnowledgeCapabilities()
+        assert caps.kinds == []
+        assert caps.search_mode is None
+        assert caps.query_language is None
+
+    def test_model_dump_carries_exactly_the_declared_fields(self):
+        # Asserting the key set, not a subset, so adding a capability fails here first.
+        assert set(KnowledgeCapabilities().model_dump()) == CAPABILITY_FIELDS
+
+    def test_kinds_is_not_shared_between_instances(self):
+        first = KnowledgeCapabilities()
+        second = KnowledgeCapabilities()
+        first.kinds.append("vector")
+        assert second.kinds == []
+
+    def test_kinds_is_an_open_taxonomy(self):
+        caps = KnowledgeCapabilities(kinds=["vector", "graph", "something-new"])
+        assert caps.kinds == ["vector", "graph", "something-new"]
+
+    def test_unknown_search_mode_is_rejected(self):
+        with pytest.raises(ValidationError):
+            KnowledgeCapabilities(search=True, search_mode="hybrid")
+
+
+class TestCapabilitiesAreNotValidatedAtModelLevel:
+    """Incoherent declarations must construct; KnowledgeBase.__init__ is what refuses them."""
+
+    def test_query_without_a_query_language_constructs(self):
+        assert KnowledgeCapabilities(query=True).query_language is None
+
+    def test_query_language_without_query_constructs(self):
+        assert KnowledgeCapabilities(query_language="sql").query is False
+
+    def test_a_wholly_unreachable_declaration_constructs(self):
+        caps = KnowledgeCapabilities()
+        assert not any([caps.search, caps.query, caps.fetch, caps.browse])
+
+    def test_search_without_a_search_mode_is_legal(self):
+        # search_mode is advisory metadata, not bidirectional with search, unlike query_language.
+        caps = KnowledgeCapabilities(search=True)
+        assert caps.search is True
+        assert caps.search_mode is None
+
+
+class TestRecordTypedDicts:
+    """The record types are documentation; nothing validates them at runtime."""
+
+    def test_every_metadata_key_is_optional(self):
+        assert KnowledgeMetadata.__total__ is False
+        assert KnowledgeMetadata.__optional_keys__ == frozenset({"id", "source", "title", "kind", "trust", "stale", "links"})
+        assert KnowledgeMetadata.__required_keys__ == frozenset()
+
+    def test_every_record_key_is_optional(self):
+        assert KnowledgeRecord.__total__ is False
+        assert KnowledgeRecord.__optional_keys__ == frozenset({"text", "metadata"})
+        assert KnowledgeRecord.__required_keys__ == frozenset()
+
+    def test_backend_specific_keys_are_not_rejected(self):
+        record = KnowledgeRecord(text="hello", distance=0.42)
+        assert record == {"text": "hello", "distance": 0.42}
+
+
+class TestKnowledgeErrors:
+    def test_every_error_shares_one_base(self):
+        assert issubclass(KnowledgeCapabilityError, KnowledgeError)
+        assert issubclass(KnowledgePathError, KnowledgeError)
+        assert issubclass(KnowledgeError, Exception)
+
+    def test_capability_error_is_not_a_not_implemented_error(self):
+        # A declaration mismatch must stay distinguishable from an unimplemented abstract method.
+        assert not issubclass(KnowledgeCapabilityError, NotImplementedError)
+
+    def test_capability_error_names_subject_and_operation(self):
+        error = KnowledgeCapabilityError("starburst", "write")
+        assert str(error) == "starburst does not support capability: write"
+        assert error.subject == "starburst"
+        assert error.capability == "write"
+
+    def test_capability_error_without_a_subject(self):
+        error = KnowledgeCapabilityError("browse")
+        assert str(error) == "unsupported capability: browse"
+        assert error.subject is None
+        assert error.capability == "browse"
+
+    def test_capability_error_without_arguments(self):
+        error = KnowledgeCapabilityError()
+        assert str(error) == ""
+        assert error.subject is None
+        assert error.capability == ""
+
+
+class TestValidateCapabilities:
+    """The invariants KnowledgeBase.__init__ enforces on a declaration.
+
+    Static, so it is exercised straight off the class — no backend needed.
+    """
+
+    def test_a_reachable_declaration_passes(self):
+        KnowledgeBase.validate_capabilities(KnowledgeCapabilities(search=True), "chromadb")
+
+    def test_writable_alone_is_reachable(self):
+        # A write-only sink is a legitimate backend, so writable counts toward reachability.
+        KnowledgeBase.validate_capabilities(KnowledgeCapabilities(writable=True), "sink")
+
+    def test_a_declaration_with_no_capability_is_rejected(self):
+        with pytest.raises(ValueError, match="declares no capability"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(), "empty")
+
+    def test_query_without_a_query_language_is_rejected(self):
+        with pytest.raises(ValueError, match="declares query=True without a query_language"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(query=True), "neo4j")
+
+    def test_query_language_without_query_is_rejected(self):
+        with pytest.raises(ValueError, match="declares query_language 'sql' without query=True"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(search=True, query_language="sql"), "starburst")
+
+    def test_a_blank_query_language_does_not_satisfy_query(self):
+        with pytest.raises(ValueError, match="without a query_language"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(query=True, query_language="   "), "neo4j")
+
+    def test_a_blank_query_language_does_not_trip_the_reverse_check(self):
+        KnowledgeBase.validate_capabilities(KnowledgeCapabilities(search=True, query_language="   "), "chromadb")
+
+    def test_unreachability_is_reported_before_query_incoherence(self):
+        # Wrong in both ways at once: the caller should hear the more fundamental problem.
+        with pytest.raises(ValueError, match="declares no capability"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(query_language="sql"), "broken")
+
+    def test_every_message_names_the_given_subject(self):
+        with pytest.raises(ValueError, match="'my-backend'"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(), "my-backend")
+        with pytest.raises(ValueError, match="'my-backend'"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(query=True), "my-backend")
+        with pytest.raises(ValueError, match="'my-backend'"):
+            KnowledgeBase.validate_capabilities(KnowledgeCapabilities(search=True, query_language="sql"), "my-backend")

--- a/docs/docs/advanced/knowledge-bases.md
+++ b/docs/docs/advanced/knowledge-bases.md
@@ -198,19 +198,33 @@ See the per-backend READMEs for step-by-step usage and routing behavior:
 
 ## Custom KnowledgeBase Adapters
 
-You can bring your own storage backend by subclassing `KnowledgeBase`. Any backend registered with `KnowledgeBuilder` (built-in or custom) is exposed to agents through the same `read_kb` / `write_kb` / `get_schemas` tools.
+You can bring your own storage backend by subclassing `KnowledgeBase`. Any backend registered with `KnowledgeBuilder` (built-in or custom) is exposed to agents through the same `read_kb` / `write_kb` / `get_schemas` tools, plus `search_kb` / `fetch_kb` / `browse_kb` where the registered backends declare those capabilities.
 
 ### Minimal implementation
 
-Subclass `KnowledgeBase` and implement the five required members: `connect`, `write`, `read`, `backend_name`, and `get_description`:
+Three members stay abstract — `backend_name`, `connect`, and `get_description`. Everything else is
+optional, and which of them you implement is fixed by the `KnowledgeCapabilities` you declare to
+`super().__init__()`: an operation you do not declare raises `KnowledgeCapabilityError` instead of
+returning an empty result, so the declaration and the implemented set must agree.
 
 ```python
 from typing import Any, Iterable, List, Mapping
-from agentkernel.knowledgebase.base import KnowledgeBase, Record
+from agentkernel.knowledgebase import KnowledgeBase, KnowledgeCapabilities, Record
 
 
 class MyBackend(KnowledgeBase):
     """Example custom knowledge base adapter."""
+
+    def __init__(self) -> None:
+        # Declare only what this backend actually supports.
+        super().__init__(
+            capabilities=KnowledgeCapabilities(
+                kinds=["vector"],
+                search=True,
+                search_mode="semantic",
+                writable=True,
+            ),
+        )
 
     @property
     def backend_name(self) -> str:
@@ -225,7 +239,7 @@ class MyBackend(KnowledgeBase):
         for record in records:
             self._client.store(record["text"], record.get("metadata", {}))
 
-    def read(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
+    def search(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
         # Return the most relevant records for the query
         raw = self._client.search(query, top_k=limit)
         return [{"text": r.text, "metadata": r.meta} for r in raw]
@@ -233,6 +247,23 @@ class MyBackend(KnowledgeBase):
     def get_description(self) -> str:
         return "MyBackend stores domain-specific knowledge and supports full-text search."
 ```
+
+Do not implement `read()`. It is concrete and routes on the declaration: a backend declaring `query`
+receives the text as a statement, and every other backend receives it as a relevance `search`. That
+routing is what lets the one `read_kb` tool serve every backend.
+
+### The operation set
+
+| Declare | Implement | Serves |
+|---|---|---|
+| `search` | `search(query, limit)` | relevance retrieval — `read_kb`, and `search_kb` when `query` is declared too |
+| `query` + `query_language` | `query(statement, limit)` | query-language retrieval — `read_kb` |
+| `fetch` | `fetch(ids)` | retrieval by identity — `fetch_kb` |
+| `browse` | `browse(path, limit)` | namespace enumeration — `browse_kb` |
+| `writable` | `write(records)` | persistence — `write_kb` |
+
+At least one of them must be declared, and declaring `query` without a `query_language` (or a
+`query_language` without `query`) is rejected in `__init__`.
 
 ### Registering the custom backend
 
@@ -257,7 +288,8 @@ kb_tools = kb.build()
 | `format_results(rows)` | Bullet-list of `text` + `source` | Custom display format for agent responses |
 | `close()` | No-op | Release connections or flush write buffers |
 | `add_schema(config)` | Merges dict into `_dynamic_schema` | Rarely needed; just call it rather than override |
-| `schema()` | Returns `{"backend": name, ...schema_config}` | If your backend needs computed schema fields |
+| `schema()` | Returns `{"backend": name, ...schema_config, "capabilities": {...}}` | Rarely needed; override `_derived_schema()` instead |
+| `_derived_schema()` | `{}` | Self-describe without `add_schema()`; declare `derives_schema=True` alongside it |
 
 
 ## When to Use Knowledge Bases vs. Memory

--- a/docs/specs/553-okf-knowledge-bases/design.md
+++ b/docs/specs/553-okf-knowledge-bases/design.md
@@ -607,7 +607,7 @@ Each is intentional; each needs a test.
     third-party subclass calling `super().__init__()` with no arguments must pass one — the only
     signature in this change that is not backward compatible, and the reason capability declaration is
     not optional. Every functioning bring-your-own backend calls `super().__init__()` today, since
-    that is what initializes `_dynamic_schema` (`base.py:28`), so this item reaches all of them; the
+    that is what initializes `_dynamic_schema` (`base.py:29`), so this item reaches all of them; the
     "no edit needed" claim under [Operation set](#operation-set-on-knowledgebase) is about the `read()`
     path only.
 

--- a/docs/specs/553-okf-knowledge-bases/design.md
+++ b/docs/specs/553-okf-knowledge-bases/design.md
@@ -34,10 +34,12 @@ what it binds a consumer to, and which of its properties drive the decisions bel
 
 ### The router leaks one backend's dialect into the shared tool
 
-- `KnowledgeBuilder.write_kb` writes Neo4j-specific metadata keys for **every** backend: it sets
-  `cypher_query` and `cypher_params` alongside the generic `query`/`params` on all writes
-  (`knowledgebuilder.py:156-166`), because `Neo4jManager.write` reads only the `cypher_*` spelling
-  (`neo4j.py:120-121`). A Chroma write carries dead Cypher keys in its stored metadata.
+- `KnowledgeBuilder.write_kb` writes Neo4j-specific metadata keys for **every** backend: on every
+  write **that carries a query**, it sets `cypher_query` and `cypher_params` alongside the generic
+  `query`/`params` (`knowledgebuilder.py:155-167`, the whole block guarded by `if resolved_query:`),
+  because `Neo4jManager.write` reads only the `cypher_*` spelling (`neo4j.py:120-121`). A
+  query-carrying Chroma write therefore stores dead Cypher keys in its metadata; a text-only write —
+  the common Chroma case — stores `{"source": ...}` alone and is unaffected.
 - `get_schemas` calls `backend.schema()` for every backend inside one `json.dumps`
   (`knowledgebuilder.py:105`) with no per-backend guard — while its sibling
   `get_all_kb_descriptions` does guard each backend (`knowledgebuilder.py:185-187`). Since
@@ -160,8 +162,9 @@ classDiagram
     declare more than one (Neo4j declares `["graph", "structured"]`).
   - `search: bool` and `search_mode: "semantic" | "lexical" | None` — relevance retrieval, and
     honestly which kind. Chroma is `semantic`; OKF is `lexical`.
-  - `query: bool` and `query_language: str | None` — e.g. `"cypher"`, `"sql"`. `query=True` requires
-    a non-empty `query_language`.
+  - `query: bool` and `query_language: str | None` — e.g. `"cypher"`, `"sql"`. The two move
+    together: `query=True` requires a non-empty `query_language`, and `query=False` requires
+    `query_language=None` (the bidirectional invariant below).
   - `fetch: bool` — retrieval by identity.
   - `browse: bool` — enumeration of the backend's namespace.
   - `writable: bool`.
@@ -172,18 +175,30 @@ classDiagram
   - A KB's shape depends on what it was constructed with: `OKFManager.capabilities.writable` folds in
     `store.writable`, which differs between a `LocalDocumentStore` and an `S3DocumentStore` over a
     read-only prefix. A `ClassVar` cannot express that.
-  - `KnowledgeBase.__init__` takes the capabilities object and validates the invariant below; every
-    subclass calls `super().__init__(capabilities=...)`. The base declares
-    `capabilities: KnowledgeCapabilities` as a bare annotation for typing, with no class-level default.
+  - `KnowledgeBase.__init__(capabilities, name=None)` takes the capabilities object and validates the
+    invariants below; every subclass calls `super().__init__(capabilities=..., name=...)`. The base
+    declares `capabilities: KnowledgeCapabilities` as a bare annotation for typing, with no
+    class-level default.
+  - The `name` argument exists **so the validation error can name the backend**. `backend_name` stays
+    an abstract property and is *not* readable during base-class validation: subclasses assign what it
+    reads only after `super().__init__()` — `StarburstManager` calls `super().__init__()` at
+    `starburst.py:60` and assigns `self.name` at `starburst.py:69`, while `backend_name` reads
+    `self.name` (`starburst.py:82`). Touching `self.backend_name` from the base `__init__` would raise
+    `AttributeError`, not the promised `ValueError`, so validation uses `name or type(self).__name__`
+    and never reads the property.
 - Declared values must be true of the instance: a backend declaring `fetch=True` must override
   `fetch()`. Verified by the contract suite (below), not by trust.
-- **Invariant, enforced at construction**: at least one of `search`, `query`, `fetch`, `browse`, or
-  `writable` is `True`. Violation raises `ValueError` naming the backend.
-  - The bar is "reachable through *some* tool", not "reachable through `read_kb`" — a write-only sink
-    (an append-only audit or event log an agent records into but never reads back) is a legitimate
-    backend, and so is a browse-only catalogue.
-  - A backend with no read capability at all is still registrable; `read_kb` routed at it returns the
-    actionable capability string, exactly as any other undeclared operation does.
+- **Invariants, enforced at construction** — each violation raises `ValueError` naming the backend
+  (from the `name` argument above, falling back to the class name):
+  - **Reachability**: at least one of `search`, `query`, `fetch`, `browse`, or `writable` is `True`.
+    - The bar is "reachable through *some* tool", not "reachable through `read_kb`" — a write-only
+      sink (an append-only audit or event log an agent records into but never reads back) is a
+      legitimate backend, and so is a browse-only catalogue.
+    - A backend with no read capability at all is still registrable; `read_kb` routed at it returns
+      the actionable capability string, exactly as any other undeclared operation does.
+  - **Query coherence**: `query_language` is non-empty **iff** `query` is `True`. Bidirectional, so a
+    backend cannot declare a query language it does not serve, and `capabilities.query` alone decides
+    the `read()` route below.
 - Declaring `kinds` as data — rather than as `VectorKB` / `StructuredKB` / `FileSystemKB` base
   classes — is the load-bearing choice; see [Deviations from the proposed class
   diagram](#deviations-from-the-proposed-class-diagram).
@@ -210,10 +225,15 @@ classDiagram
   - Dropping `**kwargs` on the read path would be a signature change; the **Non-changes** assertion
     below covers it.
 - `read(query, limit, **kwargs)` becomes a **concrete** method on the base that delegates to `query()`
-  when `capabilities.query_language` is set, else to `search()`.
+  when `capabilities.query` is `True`, else to `search()`. **This is the one statement of the routing
+  rule**; every other mention in this document refers back to it.
+  - Gating on the boolean rather than on `query_language` is what makes the rule total. With the
+    bidirectional invariant the two can no longer disagree, so a backend declaring `search` but not
+    `query` can never be routed at a `query()` that raises `KnowledgeCapabilityError`.
   - Keeps `read_kb` and every external caller working with no signature change.
   - A subclass that still overrides `read()` — including any application's own backend — keeps
-    winning, so bring-your-own backends written against today's ABC need no edit.
+    winning, so **for the read path** bring-your-own backends written against today's ABC need no
+    edit. The `__init__` signature change still reaches them: see migration item 13.
   - When a backend declares **both** `search` and `query`, `read()` routes to `query()` and the
     relevance path is reached through `search_kb` instead (see [Agent surface](#agent-surface--knowledgebuilder)).
   - Renaming `Neo4jManager.read` to `query` moves its default from `limit=10` (`neo4j.py:125`) to the
@@ -358,7 +378,9 @@ classDiagram
   writable=store.writable, derives_schema=True`.
   - `writable` is the reason capabilities are per instance — the same class over a read-only
     `S3DocumentStore` prefix declares `writable=False`.
-  - `query=False` means `read()` routes to `search()`, and `search_kb` is not emitted on its account.
+  - `query=False` (and so `query_language=None`) means `read()` routes to `search()` under the rule
+    in [Operation set](#operation-set-on-knowledgebase), and `search_kb` is not emitted on its
+    account.
   - `fetch(ids)` — bundle paths in, concept records out. The natural companion to `metadata["links"]`.
   - `browse(path)` — directory listing. At **any** level, an `index.md` in the browsed directory
     supplies the listing when present, and a derived listing is returned when it is not. `index.md` is
@@ -371,6 +393,18 @@ classDiagram
     `generated: {by, at}` stamped with the writing actor in the `<producer>/<version>` convention.
     Kept because producing OKF is the format's intended agent workflow, not only consuming it
     (`research/okf-format-survey.md` §8).
+    - **Writing actor**: `agentkernel/<installed agentkernel version>` by default, overridable per
+      manager for an application that wants to be named as the producer. One string, resolved once at
+      construction rather than per write; `spec.md` fixes its exact form.
+    - **Write-through to the manifest**: a successful `write()` inserts or replaces that concept's
+      manifest entry in the same call, so the written concept is visible to `fetch`, `browse`, and
+      `search` **immediately** — never after up to `refresh_seconds`. An agent that writes a concept
+      and then cannot read it back for five minutes would be a surprising tool surface. Asserted by a
+      test running with `refresh_seconds=None`, which proves the visibility comes from the write
+      itself and not from a refresh happening to fire.
+    - **Ids stay comma-free**: `write()` refuses a bundle path containing a `,`, which is what keeps
+      every id it hands out round-trippable through `fetch_kb` — see [Agent
+      surface](#agent-surface--knowledgebuilder).
   - `format_results` renders `id`, `title`, `type`, trust tier, and a staleness marker, so routing
     information reaches the agent rather than being flattened away.
 - **Bundle manifest and cost.** `connect()` walks the store once and holds a parsed manifest in
@@ -381,17 +415,26 @@ classDiagram
     interval has elapsed, so a bundle rewritten by a separate producer pipeline is picked up without a
     restart. `reload()` forces an immediate re-walk; `refresh_seconds=None` disables automatic
     refresh for a bundle known to be immutable.
-  - Stated consequence: an edit made underneath a running process is seen at most `refresh_seconds`
-    later, and the re-walk cost lands on whichever agent tool call crosses the boundary. This is the
-    deliberate trade and must be documented on the backend.
+  - **Concurrency**: the lazy re-walk is guarded, so two tool calls crossing the boundary together
+    produce **one** walk, not two. The first caller takes the lock and re-walks; a concurrent caller
+    does not block on it and is served the current manifest, one interval stale. The new manifest is
+    swapped in as a whole, so no caller ever observes a half-built one.
+  - Stated consequence: an **external** edit made underneath a running process is seen at most
+    `refresh_seconds` later, and the re-walk cost lands on whichever agent tool call crosses the
+    boundary. This is the deliberate trade and must be documented on the backend. It does not apply to
+    the manager's own `write()`, which is write-through (above).
   - Bodies of large bundles are read lazily per concept; frontmatter is parsed eagerly, because
     schema derivation and search ranking both need it.
 - **Declared scale.** The manifest is held per *process*, so its cost is paid once per pod in the
   ECS/pipeline topology and once per cold start on Lambda. The design targets a stated envelope
   rather than leaving it open:
   - **Design target: bundles up to 10,000 concepts**, at which the eagerly parsed frontmatter is
-    expected to stay under ~50 MB resident. Both numbers are asserted by a test over a generated
-    bundle, so a regression in per-concept overhead is caught rather than discovered in a pod.
+    expected to stay under ~50 MB. Both numbers are asserted by a test over a generated bundle, so a
+    regression in per-concept overhead is caught rather than discovered in a pod.
+    - The memory assertion is measured with `tracemalloc` around the manifest build — allocations
+      attributable to the manifest — **not** process RSS, which moves with the interpreter, the
+      allocator's retained arenas, and whatever else the test session has loaded. RSS is not
+      deterministic enough to gate CI on.
   - `max_concepts` **defaults to 10,000**: the walk stops at the limit, keeps the concepts it has, and
     records a diagnostic naming the count and the limit. It is a bound on memory, not a conformance
     rule — the bundle still loads and serves, consistent with the tolerance requirement above.
@@ -408,7 +451,15 @@ classDiagram
 - Three new capability-gated tools:
   - `search_kb(backend: str, query: str, limit: int = 3) -> str` — relevance retrieval, calling
     `search()` directly.
-  - `fetch_kb(backend: str, ids: str) -> str` — comma-separated ids.
+  - `fetch_kb(backend: str, ids: str) -> str` — comma-separated ids, split on `,` and stripped, with
+    empty segments dropped. Kept a flat string rather than a JSON-array string because tool arguments
+    are flat strings and a JSON argument is a parse failure agents hit routinely.
+    - **The separator constrains the id space**, and for OKF that constraint is real rather than
+      theoretical: the id is a bundle path, and a `,` is legal in a POSIX filename. So it is enforced
+      at both ends — `OKFManager.write()` refuses a path containing a `,`, and the manifest walk skips
+      such a file with a diagnostic — which keeps every id the backend hands out round-trippable.
+    - Generalised to the contract: a backend whose ids cannot be comma-free must not declare `fetch`.
+      Asserted by `KnowledgeBaseContract`.
   - `browse_kb(backend: str, path: str = "", limit: int = 50) -> str`.
   - Each is included in `build()`'s output **only when at least one registered backend declares that
     capability**, so a vector-only application's tool list is unchanged.
@@ -416,7 +467,8 @@ classDiagram
     naming the backends that do — matching `read_kb`'s existing error-to-string behavior
     (`knowledgebuilder.py:118-119,128-130`), never an exception into the framework.
 - **Why `search_kb` exists**: without it, a backend declaring both `search` and `query` has an
-  unreachable `search()`, because `read()` routes to `query()` whenever `query_language` is set.
+  unreachable `search()`, because `read()` routes to `query()` whenever `capabilities.query` is
+  `True`.
   - No in-tree backend is affected today — Chroma is search-only, Neo4j and Starburst are query-only,
     OKF is search-only — but the capability model exists precisely so backends can grow, and a
     declared-but-unreachable capability would be the same dishonesty the model is meant to remove.
@@ -451,14 +503,36 @@ classDiagram
   `KnowledgeBaseContract` asserts, for any backend: declared capabilities match implemented
   operations; undeclared operations raise `KnowledgeCapabilityError`; `schema()` is callable and
   returns a mapping (the `StarburstManager` collision above); records carry `metadata["id"]` when
-  `fetch` is declared; unknown keys round-trip at both record and metadata level; every operation
-  accepts `**kwargs`; the construction-time capability invariant is enforced; and `read()` routes to
-  the declared primitive, preferring `query()` when both it and `search()` are declared.
+  `fetch` is declared, and that id contains no `,`; unknown keys round-trip at both record and
+  metadata level; every operation accepts `**kwargs`; both construction-time invariants are enforced
+  and each error names the backend without reading `backend_name`; and `read()` routes on
+  `capabilities.query` — to `query()` when it is `True`, to `search()` otherwise.
 - `knowledgebase/__init__.py` gains **lazy** exports via PEP 562 `__getattr__` (the
   `deployment/aws/__init__.py` pattern) for `KnowledgeBase`, `KnowledgeBuilder`,
   `KnowledgeCapabilities`, `Record`, `KnowledgeRecord`, `KnowledgeMetadata`, and the errors — fixing
   the import documented at `docs/docs/core-concepts/overview.md:353` without making
   `chromadb`/`neo4j`/`trino`/`boto3` eager.
+
+### Example and documentation
+
+Steps 7-8 of `ak-dev-new-knowledgebase-integration` make a runnable example and the docs surfaces part
+of "complete" for a new backend, and the PR guidelines ask for an example with a new feature. Both are
+**requirements of this change**, not a later docs-sync iteration:
+
+- `examples/cli/knowledgebase/openai/okf/` — in the shape of its siblings (`chromadb/`, `neo4j/`,
+  `starburst/`): a small checked-in OKF bundle served by a `LocalDocumentStore`, an agent wired
+  through `KnowledgeBuilder`, and a `README.md` exercising `browse_kb` → `fetch_kb` → `search_kb`
+  against real bundle paths, which is the capability-gated tool set this change exists to make
+  reachable.
+- `docs/docs/advanced/knowledge-bases.md` — the capability model (`KnowledgeCapabilities`, the five
+  operations, which tools each capability emits), the OKF backend, and `DocumentStore` local-vs-S3
+  configuration.
+- `docs/docs/core-concepts/overview.md` — the documented import at `overview.md:353` starts working
+  with the lazy exports above; the surrounding text is corrected from `read`/`write` alone to the
+  operation set.
+- The prompt-visible migration items — `schema()` gaining `"capabilities"`, and `StarburstManager`'s
+  `schema` attribute becoming `db_schema` — are called out in the docs, because they change what an
+  already-deployed agent sees.
 
 ### Security
 
@@ -529,9 +603,13 @@ Each is intentional; each needs a test.
     `cypher_query`/`cypher_params`, and skips a record carrying neither with a logged warning instead
     of calling the driver with `None` (`neo4j.py:118-123`). Required by item 5: `write_kb` no longer
     emits the `cypher_*` keys, and the fallback is what keeps old-shape records working.
-13. `KnowledgeBase.__init__` requires a `capabilities` argument. A third-party subclass calling
-    `super().__init__()` with no arguments must pass one — the only signature in this change that is
-    not backward compatible, and the reason capability declaration is not optional.
+13. `KnowledgeBase.__init__` requires a `capabilities` argument (`name` stays optional). A
+    third-party subclass calling `super().__init__()` with no arguments must pass one — the only
+    signature in this change that is not backward compatible, and the reason capability declaration is
+    not optional. Every functioning bring-your-own backend calls `super().__init__()` today, since
+    that is what initializes `_dynamic_schema` (`base.py:28`), so this item reaches all of them; the
+    "no edit needed" claim under [Operation set](#operation-set-on-knowledgebase) is about the `read()`
+    path only.
 
 **Non-changes**, to be asserted: `Record` stays `Mapping[str, Any]` and stays the type on every
 signature (`KnowledgeMetadata`/`KnowledgeRecord` are documentation-only); `read`/`write` signatures,
@@ -582,7 +660,8 @@ is adopted as-is in substance. Two changes:
 - Changing any framework adapter, `Runtime`, `Session`, or the system-tool factory. Knowledge-base
   tools remain application-bound through `KnowledgeBuilder.build()`.
 - Migrating metadata already written by the current `write_kb` (item 5 above).
-- Rewriting `semantic_map`, the KB router pattern, or the existing examples.
+- Rewriting `semantic_map`, the KB router pattern, or the **existing** examples. The new OKF example
+  and the docs updates are in scope — see [Example and documentation](#example-and-documentation).
 
 ## Decisions
 
@@ -604,7 +683,8 @@ Resolved with the maintainer on 2026-08-31. The requirements above already refle
 4. **Manifest refresh — lazy automatic refresh, `refresh_seconds` default 300.** The manifest re-walks
    on the first access after the interval elapses; `reload()` forces one immediately;
    `refresh_seconds=None` opts out for an immutable bundle. Chosen so an S3 bundle rewritten by a
-   separate producer pipeline is picked up without a restart.
+   separate producer pipeline is picked up without a restart. It governs external producers only —
+   the manager's own writes are write-through (item 10).
 5. **OKF version — v0.2 only.** No v0.1 read translation and no v0.1 writes. A v0.1 bundle still
    *loads*, because the conformance rules forbid rejecting a concept for unknown frontmatter keys —
    but `timestamp` and a body `# Citations` list are carried through as unrecognised content rather
@@ -620,3 +700,19 @@ Resolved with the maintainer on 2026-08-31. The requirements above already refle
 8. **Verification gate — stands.** Every `[SPEC]`-marked claim in `research/okf-format-survey.md` must
    be re-checked verbatim against the OKF **v0.2** specification text before `spec.md` fixes
    conformance behavior.
+
+Items 9-11 were resolved in review of this document on 2026-09-01.
+
+9. **`read()` routes on `capabilities.query`, and `query_language` is bidirectional with it.** Gating
+   on `query_language` left `query=False` with a language set constructible, which would have routed
+   `read()` at a `query()` that raises even though `search` was declared and implemented. The boolean
+   is the gate, the invariant makes the two inseparable, and the rule is stated once — in [Operation
+   set](#operation-set-on-knowledgebase).
+10. **`write()` is write-through, not refresh-delayed.** A concept is visible to `fetch`/`browse`/
+    `search` in the call after the write, independent of `refresh_seconds`. `refresh_seconds` governs
+    *external* producers only. The alternative — the manager's own writes invisible for up to five
+    minutes — is a tool surface no agent could reason about.
+11. **`fetch_kb` ids stay comma-separated, and ids are constrained to match.** A JSON-array argument
+    trades a parse failure agents hit routinely for an id-space restriction they never hit; the
+    restriction is enforced at write and walk time rather than assumed, so it cannot silently produce
+    an unfetchable id.

--- a/docs/specs/553-okf-knowledge-bases/design.md
+++ b/docs/specs/553-okf-knowledge-bases/design.md
@@ -43,6 +43,18 @@ what it binds a consumer to, and which of its properties drive the decisions bel
   `get_all_kb_descriptions` does guard each backend (`knowledgebuilder.py:185-187`). Since
   `schema()` raises `ValueError` when `add_schema()` was never called (`base.py:57-58`), one
   unconfigured backend makes the agent's first tool call raise into the framework.
+- **`StarburstManager.schema` shadows the base `schema()` method**, so `get_schemas` is broken today
+  for every Starburst deployment — not only unconfigured ones.
+  - `__init__` assigns the Trino schema name to the same attribute (`self.schema = schema`,
+    `starburst.py:67`) that `KnowledgeBase` defines as a method (`base.py:50`). The instance
+    attribute wins, so `backend.schema()` at `knowledgebuilder.py:105` raises
+    `TypeError: 'str' object is not callable`.
+  - This fires even though the example does call `.add_schema(...)`
+    (`examples/cli/knowledgebase/openai/starburst/demo.py:30`) — the configured schema is stored in
+    `_dynamic_schema` and is unreachable for the life of the object.
+  - Consequence for this change: adding `"capabilities"` to `schema()` output cannot reach Starburst,
+    and the per-backend `try/except` below would *mask* the collision as an error string rather than
+    fix it. The attribute must be renamed.
 
 ### Schemas must be hand-written, but OKF bundles carry their own
 
@@ -103,7 +115,7 @@ classDiagram
         +fetch(ids)
         +browse(path, limit)
         +write(records)
-        +read(query, limit) "alias"
+        +read(query, limit) "routes to query/search"
     }
     class KnowledgeCapabilities {
         +kinds
@@ -140,9 +152,8 @@ classDiagram
 
 ### Capability declaration
 
-- Add `KnowledgeCapabilities` (pydantic `BaseModel`, `knowledgebase/model.py`), declared as a
-  `ClassVar`-style attribute on every backend, mirroring `SandboxCapabilities`
-  (`sandbox/model.py:33-48`).
+- Add `KnowledgeCapabilities` (pydantic `BaseModel`, `knowledgebase/model.py`), mirroring the shape
+  of `SandboxCapabilities` (`sandbox/model.py:33-49`).
   - `kinds: list[str]` — advisory taxonomy surfaced to the agent, an **open list** whose conventional
     values are `vector`, `structured`, `graph`, `document`; an out-of-tree backend may declare its own
     kind without a framework release, and unknown values reach the agent unchanged. A backend may
@@ -155,11 +166,24 @@ classDiagram
   - `browse: bool` — enumeration of the backend's namespace.
   - `writable: bool`.
   - `derives_schema: bool` — whether `schema()` can self-describe without `add_schema()`.
+- Declared as an **instance attribute** set in each backend's `__init__` (`self.capabilities = ...`),
+  **not** a `ClassVar` — a deliberate divergence from `Sandbox.capabilities` (`sandbox/base.py:88`),
+  where a provider's shape is fixed by its class.
+  - A KB's shape depends on what it was constructed with: `OKFManager.capabilities.writable` folds in
+    `store.writable`, which differs between a `LocalDocumentStore` and an `S3DocumentStore` over a
+    read-only prefix. A `ClassVar` cannot express that.
+  - `KnowledgeBase.__init__` takes the capabilities object and validates the invariant below; every
+    subclass calls `super().__init__(capabilities=...)`. The base declares
+    `capabilities: KnowledgeCapabilities` as a bare annotation for typing, with no class-level default.
 - Declared values must be true of the instance: a backend declaring `fetch=True` must override
   `fetch()`. Verified by the contract suite (below), not by trust.
-- **Invariant, enforced at construction**: at least one of `search`, `query`, `fetch` is `True`,
-  otherwise the backend is unreachable through `read_kb`. Violation raises `ValueError` naming the
-  backend.
+- **Invariant, enforced at construction**: at least one of `search`, `query`, `fetch`, `browse`, or
+  `writable` is `True`. Violation raises `ValueError` naming the backend.
+  - The bar is "reachable through *some* tool", not "reachable through `read_kb`" — a write-only sink
+    (an append-only audit or event log an agent records into but never reads back) is a legitimate
+    backend, and so is a browse-only catalogue.
+  - A backend with no read capability at all is still registrable; `read_kb` routed at it returns the
+    actionable capability string, exactly as any other undeclared operation does.
 - Declaring `kinds` as data — rather than as `VectorKB` / `StructuredKB` / `FileSystemKB` base
   classes — is the load-bearing choice; see [Deviations from the proposed class
   diagram](#deviations-from-the-proposed-class-diagram).
@@ -168,22 +192,33 @@ classDiagram
 
 - Retain the existing abstract members unchanged: `backend_name`, `connect()`, `get_description()`,
   and the provided `add_schema()` / `format_results()` / `close()`.
-- Four retrieval/write operations, each **optional** with a base implementation that raises
-  `KnowledgeCapabilityError(backend_name, operation)` — the `sandbox/base.py:39-69` shape:
+- Five operations — four retrieval plus `write` — each **optional**, with a base implementation that
+  raises `KnowledgeCapabilityError(backend_name, operation)` — the `sandbox/base.py:39-69` shape:
 
   | Operation | Signature | Declared by |
   |---|---|---|
-  | `search` | `(query: str, limit: int = 3) -> list[Record]` | `capabilities.search` |
-  | `query` | `(statement: str, limit: int = 3) -> list[Record]` | `capabilities.query` |
-  | `fetch` | `(ids: list[str]) -> list[Record]` | `capabilities.fetch` |
-  | `browse` | `(path: str = "", limit: int = 50) -> list[Record]` | `capabilities.browse` |
+  | `search` | `(query: str, limit: int = 3, **kwargs) -> list[Record]` | `capabilities.search` |
+  | `query` | `(statement: str, limit: int = 3, **kwargs) -> list[Record]` | `capabilities.query` |
+  | `fetch` | `(ids: list[str], **kwargs) -> list[Record]` | `capabilities.fetch` |
+  | `browse` | `(path: str = "", limit: int = 50, **kwargs) -> list[Record]` | `capabilities.browse` |
   | `write` | `(records: Iterable[Record], **kwargs) -> None` | `capabilities.writable` |
 
-- `read(query, limit)` becomes a **concrete** method on the base that delegates to `query()` when
-  `capabilities.query_language` is set, else to `search()`.
+- **Every operation keeps `**kwargs`**, matching today's `read`/`write` (`base.py:74,84`) and all three
+  backends (`chroma.py:102`, `neo4j.py:125`, `starburst.py`), which already accept and ignore it.
+  - `read()` forwards its `**kwargs` unchanged to whichever primitive it delegates to, so a caller
+    passing backend-specific options through `read()` reaches the same code it reaches today.
+  - Dropping `**kwargs` on the read path would be a signature change; the **Non-changes** assertion
+    below covers it.
+- `read(query, limit, **kwargs)` becomes a **concrete** method on the base that delegates to `query()`
+  when `capabilities.query_language` is set, else to `search()`.
   - Keeps `read_kb` and every external caller working with no signature change.
   - A subclass that still overrides `read()` — including any application's own backend — keeps
     winning, so bring-your-own backends written against today's ABC need no edit.
+  - When a backend declares **both** `search` and `query`, `read()` routes to `query()` and the
+    relevance path is reached through `search_kb` instead (see [Agent surface](#agent-surface--knowledgebuilder)).
+  - Renaming `Neo4jManager.read` to `query` moves its default from `limit=10` (`neo4j.py:125`) to the
+    base's `limit=3`. `read_kb` always passes `limit` explicitly, so only a direct
+    `neo4j.read(q)` call sees the change; it is listed as a behavioural change below.
 - Add `knowledgebase/errors.py` with `KnowledgeError` and `KnowledgeCapabilityError`, matching
   `sandbox/errors.py`. `KnowledgeCapabilityError` replaces `StarburstManager`'s ad-hoc
   `NotImplementedError` (`starburst.py:141`).
@@ -192,15 +227,29 @@ classDiagram
 
 - `Record` stays `Mapping[str, Any]` (`base.py:4`) — no runtime shape change, so no existing backend
   or user subclass is invalidated.
-- Add a `KnowledgeRecord` `TypedDict` (`total=False`) documenting the **reserved metadata keys** a
-  backend may set, so richer representations have a defined place:
-  - `id` — the backend-native identity (an OKF bundle path). Required in any record a `fetch`-capable
-    backend returns, because it is what the agent passes back to `fetch`.
-  - `source`, `title`, `kind`, `trust`, `stale`, `links`.
-  - Unknown keys are carried through untouched — asserted by the contract suite.
-- `format_results` (`base.py:94-103`) keeps its current output for records that carry only
-  `text`/`metadata.source`, and gains an `id` prefix when `metadata["id"]` is present. Backends may
-  override; `OKFManager` does.
+- Add **two** `TypedDict`s (`total=False`) so the two levels of a record are named separately — today
+  the shape `{"text": ..., "metadata": {...}}` is only a convention held in each backend's code:
+  - `KnowledgeMetadata` — the **reserved keys inside `metadata`**:
+    - `id` — the backend-native identity (an OKF bundle path). Required in the `metadata` of any
+      record a `fetch`-capable backend returns, because it is what the agent passes back to `fetch`.
+    - `source`, `title`, `kind`, `trust`, `stale`, `links`.
+  - `KnowledgeRecord` — the **whole record**: `text: str` and `metadata: KnowledgeMetadata`.
+  - Both are documentation-only: `Record` remains the runtime type on every signature, so neither is
+    validated and neither invalidates an existing backend.
+  - Unknown keys at **either** level are carried through untouched — asserted by the contract suite.
+- `format_results` (`base.py:94-103`) gains an `id` prefix, **gated on the backend declaring
+  `fetch`** — not merely on `metadata["id"]` being present:
+  - Rendered as `- [<id>] <text> (source: <source>)` when `capabilities.fetch` is `True` and
+    `metadata["id"]` is a non-empty string; the existing
+    `- <text> (source: <source>)` line (`base.py:103`) is produced in every other case, byte for byte.
+  - The gate exists because `metadata` is caller-supplied for the existing backends — a Chroma
+    deployment may already store an `id` key of its own, and an ungated prefix would silently change
+    the text those agents see. Chroma, Neo4j, and Starburst all declare `fetch=False`, so their output
+    is unchanged; it is listed as a behavioural change below regardless, because it is prompt-visible
+    for any backend that later declares `fetch`.
+  - A missing, empty, or non-string `id` on a `fetch`-capable backend degrades to the unprefixed line
+    rather than rendering `[None]`.
+  - Backends may override; `OKFManager` does.
 
 ### Schema derivation
 
@@ -214,6 +263,13 @@ classDiagram
 - `OKFManager._derived_schema()` returns the bundle's own `okf_version`, the distinct `type` values
   present, the top-level directory names, concept count, and the reserved-file inventory — read from
   the loaded bundle, never hand-transcribed.
+- **`StarburstManager`'s attribute/method collision is fixed** so that `schema()` is reachable at all:
+  the Trino schema name moves to `self.db_schema` (`starburst.py:67`, with its readers at
+  `starburst.py:111,116,204`).
+  - The constructor keyword stays `schema=`, so both existing call sites that pass it
+    (`examples/cli/knowledgebase/openai/starburst/demo.py:22`, `.../multi/demo.py:99`) are unchanged.
+  - `KnowledgeBaseContract` asserts that `schema()` is callable and returns a mapping on every
+    backend, so no future backend can reintroduce the collision with a same-named attribute.
 
 ### Storage layer — `DocumentStore`
 
@@ -276,10 +332,13 @@ classDiagram
   base class, and it exists because it carries real shared behavior for any path-addressed
   collection: holding the `DocumentStore`, normalising and validating paths, mapping
   `FileNotFoundError` to an empty result, and folding `store.writable` into its capabilities.
-- `OKFManager(store: DocumentStore, name: str = "", description: str | None = None)` composes the
-  store with the OKF parser. It declares
-  `kinds=["document"], search=True, search_mode="lexical", fetch=True, browse=True,
+- `OKFManager(store, name="", description=None, refresh_seconds=300, max_concepts=10_000)` composes
+  the store with the OKF parser, and builds its capabilities **in `__init__`** from what it was given:
+  `kinds=["document"], search=True, search_mode="lexical", query=False, fetch=True, browse=True,
   writable=store.writable, derives_schema=True`.
+  - `writable` is the reason capabilities are per instance — the same class over a read-only
+    `S3DocumentStore` prefix declares `writable=False`.
+  - `query=False` means `read()` routes to `search()`, and `search_kb` is not emitted on its account.
   - `fetch(ids)` — bundle paths in, concept records out. The natural companion to `metadata["links"]`.
   - `browse(path)` — directory listing; a bundle-root call returns `index.md`'s listing when present
     and a derived listing when it is not.
@@ -305,12 +364,28 @@ classDiagram
     deliberate trade and must be documented on the backend.
   - Bodies of large bundles are read lazily per concept; frontmatter is parsed eagerly, because
     schema derivation and search ranking both need it.
+- **Declared scale.** The manifest is held per *process*, so its cost is paid once per pod in the
+  ECS/pipeline topology and once per cold start on Lambda. The design targets a stated envelope
+  rather than leaving it open:
+  - **Design target: bundles up to 10,000 concepts**, at which the eagerly parsed frontmatter is
+    expected to stay under ~50 MB resident. Both numbers are asserted by a test over a generated
+    bundle, so a regression in per-concept overhead is caught rather than discovered in a pod.
+  - `max_concepts` **defaults to 10,000**: the walk stops at the limit, keeps the concepts it has, and
+    records a diagnostic naming the count and the limit. It is a bound on memory, not a conformance
+    rule — the bundle still loads and serves, consistent with the tolerance requirement above.
+  - Bodies are excluded from the envelope: they are read on demand and not retained between calls, so
+    total bundle *bytes* on disk or in S3 is not the limiting dimension — concept count is.
+  - A deployment needing more raises `max_concepts` explicitly and owns the memory consequence. There
+    is no automatic spill to disk, no LRU eviction, and no shared cross-pod cache; each is a
+    non-goal below.
 
 ### Agent surface — `KnowledgeBuilder`
 
 - The four existing tools keep their names and signatures: `get_schemas`, `read_kb`, `write_kb`,
   `get_all_kb_descriptions`.
-- Two new capability-gated tools:
+- Three new capability-gated tools:
+  - `search_kb(backend: str, query: str, limit: int = 3) -> str` — relevance retrieval, calling
+    `search()` directly.
   - `fetch_kb(backend: str, ids: str) -> str` — comma-separated ids.
   - `browse_kb(backend: str, path: str = "", limit: int = 50) -> str`.
   - Each is included in `build()`'s output **only when at least one registered backend declares that
@@ -318,6 +393,17 @@ classDiagram
   - Routing a call at a backend that does not declare the capability returns an actionable string
     naming the backends that do — matching `read_kb`'s existing error-to-string behavior
     (`knowledgebuilder.py:118-119,128-130`), never an exception into the framework.
+- **Why `search_kb` exists**: without it, a backend declaring both `search` and `query` has an
+  unreachable `search()`, because `read()` routes to `query()` whenever `query_language` is set.
+  - No in-tree backend is affected today — Chroma is search-only, Neo4j and Starburst are query-only,
+    OKF is search-only — but the capability model exists precisely so backends can grow, and a
+    declared-but-unreachable capability would be the same dishonesty the model is meant to remove.
+  - `search_kb`'s gate is narrower than the other two: it is emitted only when at least one backend
+    declares **both** `search` and `query`. For a search-only backend `read_kb` already reaches
+    `search()`, and emitting a second tool that does the same thing would only give the agent a
+    redundant choice.
+  - The gate is a property of the registered set, not of one backend: once emitted, `search_kb` routes
+    at any backend declaring `search`, and returns the capability string for the others.
 - `write_kb` stops emitting Neo4j's `cypher_query` / `cypher_params` keys
   (`knowledgebuilder.py:157-166`); it emits the generic `query` / `params` only.
   - `Neo4jManager.write` reads `query`/`params` first and falls back to `cypher_query`/`cypher_params`
@@ -338,12 +424,16 @@ classDiagram
 - `knowledgebase/testing.py` ships `KnowledgeBaseContract` and `DocumentStoreContract`, reusable
   suites in the `SandboxProviderContract` (`sandbox/testing.py:130`) / `QueueTransportContract` shape.
   `KnowledgeBaseContract` asserts, for any backend: declared capabilities match implemented
-  operations; undeclared operations raise `KnowledgeCapabilityError`; records carry `id` when
-  `fetch` is declared; unknown metadata keys round-trip; `read()` routes to the declared primitive.
+  operations; undeclared operations raise `KnowledgeCapabilityError`; `schema()` is callable and
+  returns a mapping (the `StarburstManager` collision above); records carry `metadata["id"]` when
+  `fetch` is declared; unknown keys round-trip at both record and metadata level; every operation
+  accepts `**kwargs`; the construction-time capability invariant is enforced; and `read()` routes to
+  the declared primitive, preferring `query()` when both it and `search()` are declared.
 - `knowledgebase/__init__.py` gains **lazy** exports via PEP 562 `__getattr__` (the
   `deployment/aws/__init__.py` pattern) for `KnowledgeBase`, `KnowledgeBuilder`,
-  `KnowledgeCapabilities`, `Record`, and the errors — fixing the import documented at
-  `docs/docs/core-concepts/overview.md:353` without making `chromadb`/`neo4j`/`trino`/`boto3` eager.
+  `KnowledgeCapabilities`, `Record`, `KnowledgeRecord`, `KnowledgeMetadata`, and the errors — fixing
+  the import documented at `docs/docs/core-concepts/overview.md:353` without making
+  `chromadb`/`neo4j`/`trino`/`boto3` eager.
 
 ### Security
 
@@ -391,16 +481,32 @@ Each is intentional; each needs a test.
    agent-issued writes are unaffected; **records already stored by Chroma carry the dead keys and are
    not migrated**.
 6. `get_schemas` degrades per backend instead of failing the call.
-7. `build()` may return six callables rather than four, when a registered backend declares `fetch`
-   or `browse`.
+7. `build()` may return up to seven callables rather than four, when registered backends declare
+   `fetch`, `browse`, or both `search` and `query`.
 8. `agentkernel.knowledgebase` exports names for the first time — additive; the documented import
    starts working.
+9. `StarburstManager`'s Trino schema name moves from `self.schema` to `self.db_schema`
+   (`starburst.py:67`). The `schema=` constructor keyword is unchanged, so no call site moves; code
+   reading `manager.schema` as a string must be updated — in-tree there is none, and the read now
+   returns the inherited `schema()` method. `get_schemas` starts returning a real schema for
+   Starburst backends instead of raising `TypeError`, which is a prompt-visible change for every
+   Starburst deployment.
+10. `format_results` prefixes `[<id>]` for backends declaring `fetch`. No existing backend declares
+    it, so in-tree output is unchanged; the rule is listed because it is prompt-visible the moment a
+    `fetch`-capable backend is registered.
+11. `Neo4jManager.query` (formerly `read`) defaults to `limit=3` instead of `limit=10`
+    (`neo4j.py:125`). `read_kb` always passes `limit`, so only direct callers see it.
+12. `KnowledgeBase.__init__` requires a `capabilities` argument. A third-party subclass calling
+    `super().__init__()` with no arguments must pass one — the only signature in this change that is
+    not backward compatible, and the reason capability declaration is not optional.
 
-**Non-changes**, to be asserted: `Record` stays `Mapping[str, Any]`; `read`/`write` signatures;
-the four existing tool names and signatures; `KnowledgeBuilder.__init__`'s `backends` +
-`semantic_map` signature; `add_schema`/`format_results`/`close`; no framework adapter changes; no
-`AKConfig` section added; every existing example (`examples/cli/knowledgebase/openai/*`) runs
-unmodified.
+**Non-changes**, to be asserted: `Record` stays `Mapping[str, Any]` and stays the type on every
+signature (`KnowledgeMetadata`/`KnowledgeRecord` are documentation-only); `read`/`write` signatures,
+including their `**kwargs`, which every new operation also carries; the four existing tool names and
+signatures; `KnowledgeBuilder.__init__`'s `backends` + `semantic_map` signature;
+`add_schema`/`format_results`/`close`; the `schema=` keyword on `StarburstManager.__init__`; no
+framework adapter changes; no `AKConfig` section added; every existing example
+(`examples/cli/knowledgebase/openai/*`) runs unmodified.
 
 ## Deviations from the proposed class diagram
 
@@ -438,6 +544,8 @@ is adopted as-is in substance. Two changes:
   pipeline is a separate change.
 - **A `knowledgebase` block in `AKConfig`.** Backends stay application-constructed, as today.
 - Bundle-level concurrency control, versioning, or locking on write.
+- A shared or cross-pod manifest cache, spill-to-disk, or LRU eviction. The manifest is per process
+  and bounded by `max_concepts`; a bundle outgrowing that envelope is a separate change.
 - Changing any framework adapter, `Runtime`, `Session`, or the system-tool factory. Knowledge-base
   tools remain application-bound through `KnowledgeBuilder.build()`.
 - Migrating metadata already written by the current `write_kb` (item 5 above).
@@ -454,10 +562,12 @@ Resolved with the maintainer on 2026-08-31. The requirements above already refle
    conventional values, not a closed enum. Extensibility wins over agent-side routability, and the
    values are advisory anyway — routing is driven by the boolean capability flags and
    `get_description()`, not by `kinds`.
-3. **Record typing — `KnowledgeRecord` as a `TypedDict`.** Reserved keys get a documented home,
-   `Record` stays `Mapping[str, Any]`, and no existing backend or user subclass is invalidated. The
-   "a `fetch`-capable backend must set `id`" rule is enforced by `KnowledgeBaseContract`, not by
-   runtime validation.
+3. **Record typing — `KnowledgeMetadata` + `KnowledgeRecord` as `TypedDict`s.** Two types, because
+   the reserved keys live inside `metadata` while the record itself is `{"text", "metadata"}`; one
+   type covering both levels would leave "a `fetch`-capable backend must set `id`" ambiguous about
+   where `id` goes. `Record` stays `Mapping[str, Any]` on every signature, so no existing backend or
+   user subclass is invalidated, and the `id` rule is enforced by `KnowledgeBaseContract` rather than
+   by runtime validation.
 4. **Manifest refresh — lazy automatic refresh, `refresh_seconds` default 300.** The manifest re-walks
    on the first access after the interval elapses; `reload()` forces one immediately;
    `refresh_seconds=None` opts out for an immutable bundle. Chosen so an S3 bundle rewritten by a
@@ -467,6 +577,13 @@ Resolved with the maintainer on 2026-08-31. The requirements above already refle
    but `timestamp` and a body `# Citations` list are carried through as unrecognised content rather
    than mapped onto `generated` / `sources`, and a declared `okf_version` other than `0.2` is recorded
    as a bundle diagnostic.
-6. **Verification gate — stands.** Every `[SPEC]`-marked claim in `research/okf-format-survey.md` must
+6. **Capabilities are per instance, not per class.** `Sandbox` fixes its shape on the class
+   (`sandbox/base.py:88`); a KB's shape depends on its constructor arguments — `writable` follows the
+   injected `DocumentStore`. Validated in `KnowledgeBase.__init__`, which is what makes the
+   at-least-one-capability invariant enforceable.
+7. **Manifest envelope — 10,000 concepts / ~50 MB, `max_concepts` truncates with a diagnostic.** A
+   declared and tested bound, rather than an open-ended in-process cache, because the manifest is
+   held per pod and per Lambda cold start. Raising it is an explicit, application-owned decision.
+8. **Verification gate — stands.** Every `[SPEC]`-marked claim in `research/okf-format-survey.md` must
    be re-checked verbatim against the OKF **v0.2** specification text before `spec.md` fixes
    conformance behavior.

--- a/docs/specs/553-okf-knowledge-bases/design.md
+++ b/docs/specs/553-okf-knowledge-bases/design.md
@@ -258,8 +258,14 @@ classDiagram
     an explicit `add_schema()` value always wins over a derived one.
   - Also add `"capabilities": capabilities.model_dump()` so the agent is told what the backend can do
     from the same call it already makes.
-- The hard failure at `base.py:57-58` is relaxed: it raises only when the schema is empty **and**
-  `capabilities.derives_schema` is `False`. A backend that self-describes needs no `add_schema()`.
+- The hard failure at `base.py:57-58` is relaxed: it raises only when **both** `_dynamic_schema` and
+  `_derived_schema()` are empty. The unconditional `{"backend": name}` and `"capabilities"` entries
+  never count as content — otherwise the guard could never fire again. A backend that self-describes
+  needs no `add_schema()`; a backend that neither derives nor was configured still fails loudly,
+  exactly as today.
+  - `capabilities.derives_schema` is a declaration, not the gate: it tells the agent that
+    `_derived_schema()` is expected to be non-empty, and `KnowledgeBaseContract` fails a backend that
+    declares it while returning `{}` rather than letting it serve a content-free schema.
 - `OKFManager._derived_schema()` returns the bundle's own `okf_version`, the distinct `type` values
   present, the top-level directory names, concept count, and the reserved-file inventory — read from
   the loaded bundle, never hand-transcribed.
@@ -281,14 +287,27 @@ classDiagram
     KB above it folds that into `capabilities.writable`.
   - Paths are POSIX-style and **bundle-relative**; the store owns the mapping to a filesystem path or
     an object key.
+  - **The store owns containment.** Every path it accepts or emits — through `read_bytes`, `exists`,
+    `write_bytes`, and every entry `list()` returns — is normalised and confined to the store's own
+    namespace; one that escapes is refused, never resolved. Containment therefore also covers paths no
+    agent supplied: the manifest walk and links read out of a concept. `LocalDocumentStore` enforces it
+    during **traversal** as well as access — `..` segments and absolute paths are rejected, and a
+    symlink resolving outside `root` is skipped by the walk and refused on read.
+  - `list()` returns paths in **lexicographic order**. Ordering is part of the contract because
+    `max_concepts` truncation keeps a prefix of the walk: an unordered store would give two pods
+    different concept sets for the same over-limit bundle.
 - `LocalDocumentStore(root: str)` — local filesystem. No extra required (stdlib only).
 - `S3DocumentStore(bucket: str, prefix: str = "", region: str | None = None, client=None)` — requires
   the existing `aws` extra (`boto3>=1.41.4`, already in `pyproject.toml`); no new extra.
-  - `list()` paginates; `read_bytes` maps `NoSuchKey` to `FileNotFoundError` so the layer above sees
-    one exception type regardless of store.
-- `DocumentStore.from_uri(uri)` resolves `file://…` / a bare path → `LocalDocumentStore`, `s3://bucket/prefix`
-  → `S3DocumentStore`, and any other value as a dotted path via `resolve_dotted`
-  (`core/util/factory.py:26`), raising `AKConfigError` otherwise.
+  - `list()` paginates and merges pages in key order (S3 already lists in UTF-8 binary order);
+    `read_bytes` maps `NoSuchKey` to `FileNotFoundError` so the layer above sees one exception type
+    regardless of store.
+- `DocumentStore.from_uri(uri)` resolves by **explicit scheme**: `file://…` or a bare path →
+  `LocalDocumentStore`; `s3://bucket/prefix` → `S3DocumentStore`; `python:pkg.module.ClassName` →
+  `resolve_dotted` (`core/util/factory.py:26`). Any other scheme raises `AKConfigError`.
+  - The `python:` prefix is required because a dotted path *is* a bare path. Without a discriminator,
+    `mypkg.stores.GitStore` would silently become a `LocalDocumentStore` rooted at a directory that
+    does not exist, and the bring-your-own-store branch would be unreachable.
   - This is what makes local-in-dev / S3-in-prod a one-environment-variable change without the KB
     tier gaining an `AKConfig` section (see [Decisions](#decisions) 1).
 - Stores take **explicit constructor parameters and never read `AKConfig`**, matching the shared-driver
@@ -330,8 +349,9 @@ classDiagram
 
 - `DocumentKnowledgeBase` (abstract, `knowledgebase/document.py`) is the **only** new intermediate
   base class, and it exists because it carries real shared behavior for any path-addressed
-  collection: holding the `DocumentStore`, normalising and validating paths, mapping
-  `FileNotFoundError` to an empty result, and folding `store.writable` into its capabilities.
+  collection: holding the `DocumentStore`, mapping a store's containment refusal to an agent-facing
+  error result and `FileNotFoundError` to an empty one, and folding `store.writable` into its
+  capabilities. Containment itself is enforced by the store, not here.
 - `OKFManager(store, name="", description=None, refresh_seconds=300, max_concepts=10_000)` composes
   the store with the OKF parser, and builds its capabilities **in `__init__`** from what it was given:
   `kinds=["document"], search=True, search_mode="lexical", query=False, fetch=True, browse=True,
@@ -340,8 +360,10 @@ classDiagram
     `S3DocumentStore` prefix declares `writable=False`.
   - `query=False` means `read()` routes to `search()`, and `search_kb` is not emitted on its account.
   - `fetch(ids)` — bundle paths in, concept records out. The natural companion to `metadata["links"]`.
-  - `browse(path)` — directory listing; a bundle-root call returns `index.md`'s listing when present
-    and a derived listing when it is not.
+  - `browse(path)` — directory listing. At **any** level, an `index.md` in the browsed directory
+    supplies the listing when present, and a derived listing is returned when it is not. `index.md` is
+    reserved at every directory level (`research/okf-format-survey.md` §2), so a curated listing for
+    `datasets/` is honoured exactly as the bundle root's is.
   - `search(query, limit)` — **lexical**, over frontmatter (`title`, `description`, `tags`, `type`)
     and body text, ranked by field-weighted term overlap. Declared as `lexical` precisely so no
     caller mistakes it for embedding search.
@@ -405,9 +427,12 @@ classDiagram
   - The gate is a property of the registered set, not of one backend: once emitted, `search_kb` routes
     at any backend declaring `search`, and returns the capability string for the others.
 - `write_kb` stops emitting Neo4j's `cypher_query` / `cypher_params` keys
-  (`knowledgebuilder.py:157-166`); it emits the generic `query` / `params` only.
-  - `Neo4jManager.write` reads `query`/`params` first and falls back to `cypher_query`/`cypher_params`
-    (`neo4j.py:120-121`), so a caller writing records by hand in the old shape still works.
+  (`knowledgebuilder.py:156-167`); it emits the generic `query` / `params` only.
+  - **`Neo4jManager.write` changes in the same commit.** It reads *only* the `cypher_*` spelling today
+    (`neo4j.py:120-121`), so dropping those keys without touching it would call `_run(None, {})` on
+    every agent-issued write. It is changed to read `query`/`params` first and fall back to
+    `cypher_query`/`cypher_params`, keeping hand-written old-shape records working, and to skip a
+    record carrying neither with a logged warning rather than handing `None` to the driver.
 - `get_schemas` gains the same per-backend `try/except` its sibling `get_all_kb_descriptions` already
   has (`knowledgebuilder.py:185-187`), reporting the failing backend inline instead of failing the
   whole call.
@@ -437,9 +462,13 @@ classDiagram
 
 ### Security
 
-- **Path containment**: every agent-supplied id or path reaching `fetch`/`browse`/`write` is
-  normalised and rejected if it escapes the bundle root — `..` segments, absolute paths, and symlinks
-  that resolve outside `LocalDocumentStore.root`. Rejection is an error result, not a traversal.
+- **Path containment is the `DocumentStore`'s obligation**, stated in the store contract above rather
+  than left to each caller — so it covers paths that reach a store from anywhere: an agent
+  (`fetch`/`browse`/`write`), a link read out of a concept, and the manifest walk, which supplies no
+  agent path at all. `..` segments, absolute paths, and symlinks resolving outside
+  `LocalDocumentStore.root` are refused on access and skipped during traversal.
+  `DocumentKnowledgeBase` turns the refusal into an error result for the agent; it never stands in as
+  the only place an escape is detected.
 - **No network fetch of OKF reference fields**: `resource`, `sources[].resource`, and `computation`
   values that are absolute URLs are returned to the agent as data and never dereferenced by the KB
   layer, matching the multimodal hook's stance on remote references
@@ -496,7 +525,11 @@ Each is intentional; each needs a test.
     `fetch`-capable backend is registered.
 11. `Neo4jManager.query` (formerly `read`) defaults to `limit=3` instead of `limit=10`
     (`neo4j.py:125`). `read_kb` always passes `limit`, so only direct callers see it.
-12. `KnowledgeBase.__init__` requires a `capabilities` argument. A third-party subclass calling
+12. `Neo4jManager.write` reads the generic `query`/`params` metadata keys, falling back to
+    `cypher_query`/`cypher_params`, and skips a record carrying neither with a logged warning instead
+    of calling the driver with `None` (`neo4j.py:118-123`). Required by item 5: `write_kb` no longer
+    emits the `cypher_*` keys, and the fallback is what keeps old-shape records working.
+13. `KnowledgeBase.__init__` requires a `capabilities` argument. A third-party subclass calling
     `super().__init__()` with no arguments must pass one — the only signature in this change that is
     not backward compatible, and the reason capability declaration is not optional.
 

--- a/docs/specs/553-okf-knowledge-bases/design.md
+++ b/docs/specs/553-okf-knowledge-bases/design.md
@@ -1,0 +1,472 @@
+# #553: Open Knowledge Format support and the knowledge-base architecture refactor
+
+Splits the knowledge-base layer along three independent axes — **representation** (what the knowledge
+*is*), **capability** (what a backend can *do* with it), and **storage** (where the bytes *live*) —
+then adds Open Knowledge Format as the first representation that exercises all three: an OKF bundle
+is parsed by format code that knows nothing about storage, served over a `DocumentStore` that knows
+nothing about OKF, and exposed to agents through the same `KnowledgeBuilder` tools every other
+backend uses. The one-sentence design idea: **a backend's shape becomes declared data
+(`KnowledgeCapabilities`), not a class hierarchy**, so the KB tier can grow new kinds of knowledge
+without growing new abstract base classes.
+
+Supporting research: [`research/okf-format-survey.md`](research/okf-format-survey.md) — what OKF is,
+what it binds a consumer to, and which of its properties drive the decisions below.
+
+## Motivation
+
+### The current contract has one retrieval hole, and OKF needs three
+
+- `KnowledgeBase` exposes exactly one retrieval operation, `read(query, limit)` (`base.py:84`), so
+  every backend must express its whole retrieval surface as one string.
+  - Chroma treats it as a semantic query (`chroma.py:111`), Neo4j as Cypher (`neo4j.py:138-143`),
+    Starburst as SQL (`starburst.py:184`). Three unrelated languages behind one signature, with
+    nothing on the object saying which.
+  - OKF's identity *is* the file path (`research/okf-format-survey.md` §2), so an agent must be able
+    to **fetch by id** and **browse a namespace**. Neither is expressible as `read(query)`.
+- There is no machine-readable statement of what a backend supports. The constraints exist, but only
+  as prose in a hand-written schema dict (`examples/cli/knowledgebase/openai/starburst/demo.py:49-52`
+  declares `"write_supported": false` as free text the runtime never reads) and as inconsistent
+  runtime failures:
+  - `StarburstManager.write` raises `NotImplementedError` (`starburst.py:141`).
+  - `StarburstManager.read` returns `[]` for a rejected statement (`starburst.py:178`) and `[]` again
+    for a genuine query failure (`starburst.py:227`) — indistinguishable from "no results".
+  - `ChromaManager` and `Neo4jManager` accept writes with no declared constraint at all.
+
+### The router leaks one backend's dialect into the shared tool
+
+- `KnowledgeBuilder.write_kb` writes Neo4j-specific metadata keys for **every** backend: it sets
+  `cypher_query` and `cypher_params` alongside the generic `query`/`params` on all writes
+  (`knowledgebuilder.py:156-166`), because `Neo4jManager.write` reads only the `cypher_*` spelling
+  (`neo4j.py:120-121`). A Chroma write carries dead Cypher keys in its stored metadata.
+- `get_schemas` calls `backend.schema()` for every backend inside one `json.dumps`
+  (`knowledgebuilder.py:105`) with no per-backend guard — while its sibling
+  `get_all_kb_descriptions` does guard each backend (`knowledgebuilder.py:185-187`). Since
+  `schema()` raises `ValueError` when `add_schema()` was never called (`base.py:57-58`), one
+  unconfigured backend makes the agent's first tool call raise into the framework.
+
+### Schemas must be hand-written, but OKF bundles carry their own
+
+- `schema()` returns only what the application passed to `add_schema()`, merged under
+  `{"backend": name}` (`base.py:60-62`), and hard-fails when nothing was passed (`base.py:57-58`).
+- An OKF bundle already declares its own concept types, index, and version
+  (`research/okf-format-survey.md` §3, §6). Requiring a deployment to hand-transcribe that into a
+  dict would guarantee drift between the bundle and what the agent is told about it.
+
+### Record and result shapes cannot carry OKF's provenance
+
+- `Record` is `Mapping[str, Any]` (`base.py:4`) and the default `format_results` renders only
+  `text` plus `metadata["source"]` (`base.py:103`).
+- OKF's load-bearing fields — path identity, `type`, trust tier, `stale_after`, `sources[]` — have
+  nowhere to go that survives to the agent (`research/okf-format-survey.md` §3).
+
+### The package is not importable the way it is documented
+
+- `knowledgebase/__init__.py` is a single comment line and exports nothing, while
+  `docs/docs/core-concepts/overview.md:353` documents `from agentkernel.knowledgebase import
+  KnowledgeBase`. That import fails today.
+- There are no tests for the knowledge-base tier anywhere under `ak-py/tests/` (the suite has files
+  for every other pluggable tier), so nothing pins the contract this change refactors.
+
+### The house patterns this change should have been using already exist
+
+- Honest per-backend capability declaration plus optional operations that raise a typed error:
+  `SandboxCapabilities` (`sandbox/model.py:33-48`) and `Sandbox.execute_command` /
+  `upload_file` defaulting to `SandboxCapabilityError` (`sandbox/base.py:39-69`).
+- Backend-selection factories: `resolve_dotted` / `require_extra` / `AKConfigError`
+  (`core/util/factory.py:18,26,50`).
+- Reusable conformance suites for pluggable tiers: `SandboxProviderContract`
+  (`sandbox/testing.py:130`) and `QueueTransportContract` (`pipeline/testing.py`).
+- Lazy public exports that keep optional dependencies optional: the PEP 562 `__getattr__` map in
+  `deployment/aws/__init__.py` behind `agentkernel/aws.py`.
+- Refusing to fetch remote references from inside a framework component, for SSRF reasons:
+  `core/multimodal/hooks.py:41,344`.
+
+## Design shape
+
+Three axes, each replaceable without touching the other two:
+
+| Axis | Question | Owns | Knows nothing about |
+|---|---|---|---|
+| **Representation** | What is this knowledge? | `OKFBundle` / `OKFConcept` parsing, frontmatter families, links, trust tiers | where bytes come from |
+| **Capability** | What can I do with it? | `KnowledgeCapabilities`, the operation set, `KnowledgeCapabilityError` | any specific backend |
+| **Storage** | Where are the bytes? | `DocumentStore`: `LocalDocumentStore`, `S3DocumentStore` | markdown, YAML, OKF |
+
+```mermaid
+classDiagram
+    class KnowledgeBase {
+        <<abstract>>
+        +backend_name
+        +capabilities : KnowledgeCapabilities
+        +schema()
+        +search(query, limit)
+        +query(statement, limit)
+        +fetch(ids)
+        +browse(path, limit)
+        +write(records)
+        +read(query, limit) "alias"
+    }
+    class KnowledgeCapabilities {
+        +kinds
+        +search / search_mode
+        +query / query_language
+        +fetch / browse / writable
+        +derives_schema
+    }
+    class DocumentKnowledgeBase {
+        <<abstract>>
+        path-addressed documents
+    }
+    class DocumentStore {
+        <<abstract>>
+        +read_bytes(path)
+        +list(prefix)
+        +exists(path)
+        +write_bytes(path, data)
+    }
+    KnowledgeBase --> KnowledgeCapabilities : declares
+    KnowledgeBase <|-- ChromaManager
+    KnowledgeBase <|-- Neo4jManager
+    KnowledgeBase <|-- StarburstManager
+    KnowledgeBase <|-- DocumentKnowledgeBase
+    DocumentKnowledgeBase <|-- OKFManager
+    DocumentKnowledgeBase o-- DocumentStore
+    DocumentStore <|-- LocalDocumentStore
+    DocumentStore <|-- S3DocumentStore
+    OKFManager ..> OKFBundle : parses via
+    OKFBundle *-- OKFConcept
+```
+
+## Requirements
+
+### Capability declaration
+
+- Add `KnowledgeCapabilities` (pydantic `BaseModel`, `knowledgebase/model.py`), declared as a
+  `ClassVar`-style attribute on every backend, mirroring `SandboxCapabilities`
+  (`sandbox/model.py:33-48`).
+  - `kinds: list[str]` — advisory taxonomy surfaced to the agent, an **open list** whose conventional
+    values are `vector`, `structured`, `graph`, `document`; an out-of-tree backend may declare its own
+    kind without a framework release, and unknown values reach the agent unchanged. A backend may
+    declare more than one (Neo4j declares `["graph", "structured"]`).
+  - `search: bool` and `search_mode: "semantic" | "lexical" | None` — relevance retrieval, and
+    honestly which kind. Chroma is `semantic`; OKF is `lexical`.
+  - `query: bool` and `query_language: str | None` — e.g. `"cypher"`, `"sql"`. `query=True` requires
+    a non-empty `query_language`.
+  - `fetch: bool` — retrieval by identity.
+  - `browse: bool` — enumeration of the backend's namespace.
+  - `writable: bool`.
+  - `derives_schema: bool` — whether `schema()` can self-describe without `add_schema()`.
+- Declared values must be true of the instance: a backend declaring `fetch=True` must override
+  `fetch()`. Verified by the contract suite (below), not by trust.
+- **Invariant, enforced at construction**: at least one of `search`, `query`, `fetch` is `True`,
+  otherwise the backend is unreachable through `read_kb`. Violation raises `ValueError` naming the
+  backend.
+- Declaring `kinds` as data — rather than as `VectorKB` / `StructuredKB` / `FileSystemKB` base
+  classes — is the load-bearing choice; see [Deviations from the proposed class
+  diagram](#deviations-from-the-proposed-class-diagram).
+
+### Operation set on `KnowledgeBase`
+
+- Retain the existing abstract members unchanged: `backend_name`, `connect()`, `get_description()`,
+  and the provided `add_schema()` / `format_results()` / `close()`.
+- Four retrieval/write operations, each **optional** with a base implementation that raises
+  `KnowledgeCapabilityError(backend_name, operation)` — the `sandbox/base.py:39-69` shape:
+
+  | Operation | Signature | Declared by |
+  |---|---|---|
+  | `search` | `(query: str, limit: int = 3) -> list[Record]` | `capabilities.search` |
+  | `query` | `(statement: str, limit: int = 3) -> list[Record]` | `capabilities.query` |
+  | `fetch` | `(ids: list[str]) -> list[Record]` | `capabilities.fetch` |
+  | `browse` | `(path: str = "", limit: int = 50) -> list[Record]` | `capabilities.browse` |
+  | `write` | `(records: Iterable[Record], **kwargs) -> None` | `capabilities.writable` |
+
+- `read(query, limit)` becomes a **concrete** method on the base that delegates to `query()` when
+  `capabilities.query_language` is set, else to `search()`.
+  - Keeps `read_kb` and every external caller working with no signature change.
+  - A subclass that still overrides `read()` — including any application's own backend — keeps
+    winning, so bring-your-own backends written against today's ABC need no edit.
+- Add `knowledgebase/errors.py` with `KnowledgeError` and `KnowledgeCapabilityError`, matching
+  `sandbox/errors.py`. `KnowledgeCapabilityError` replaces `StarburstManager`'s ad-hoc
+  `NotImplementedError` (`starburst.py:141`).
+
+### Records and result formatting
+
+- `Record` stays `Mapping[str, Any]` (`base.py:4`) — no runtime shape change, so no existing backend
+  or user subclass is invalidated.
+- Add a `KnowledgeRecord` `TypedDict` (`total=False`) documenting the **reserved metadata keys** a
+  backend may set, so richer representations have a defined place:
+  - `id` — the backend-native identity (an OKF bundle path). Required in any record a `fetch`-capable
+    backend returns, because it is what the agent passes back to `fetch`.
+  - `source`, `title`, `kind`, `trust`, `stale`, `links`.
+  - Unknown keys are carried through untouched — asserted by the contract suite.
+- `format_results` (`base.py:94-103`) keeps its current output for records that carry only
+  `text`/`metadata.source`, and gains an `id` prefix when `metadata["id"]` is present. Backends may
+  override; `OKFManager` does.
+
+### Schema derivation
+
+- `schema()` gains a `_derived_schema() -> Mapping[str, Any]` hook, defaulting to `{}`.
+  - Final schema = `{"backend": name}` + `_derived_schema()` + `_dynamic_schema`, in that order —
+    an explicit `add_schema()` value always wins over a derived one.
+  - Also add `"capabilities": capabilities.model_dump()` so the agent is told what the backend can do
+    from the same call it already makes.
+- The hard failure at `base.py:57-58` is relaxed: it raises only when the schema is empty **and**
+  `capabilities.derives_schema` is `False`. A backend that self-describes needs no `add_schema()`.
+- `OKFManager._derived_schema()` returns the bundle's own `okf_version`, the distinct `type` values
+  present, the top-level directory names, concept count, and the reserved-file inventory — read from
+  the loaded bundle, never hand-transcribed.
+
+### Storage layer — `DocumentStore`
+
+- New `knowledgebase/store/` package. `DocumentStore` is an ABC over a path namespace, with **no
+  knowledge of markdown, YAML, or OKF**:
+  - `read_bytes(path) -> bytes`, `exists(path) -> bool`, `list(prefix: str = "") -> list[str]`,
+    `write_bytes(path, data) -> None`, `close() -> None`.
+  - `writable: bool` property — `S3DocumentStore` over a read-only prefix declares `False`, and the
+    KB above it folds that into `capabilities.writable`.
+  - Paths are POSIX-style and **bundle-relative**; the store owns the mapping to a filesystem path or
+    an object key.
+- `LocalDocumentStore(root: str)` — local filesystem. No extra required (stdlib only).
+- `S3DocumentStore(bucket: str, prefix: str = "", region: str | None = None, client=None)` — requires
+  the existing `aws` extra (`boto3>=1.41.4`, already in `pyproject.toml`); no new extra.
+  - `list()` paginates; `read_bytes` maps `NoSuchKey` to `FileNotFoundError` so the layer above sees
+    one exception type regardless of store.
+- `DocumentStore.from_uri(uri)` resolves `file://…` / a bare path → `LocalDocumentStore`, `s3://bucket/prefix`
+  → `S3DocumentStore`, and any other value as a dotted path via `resolve_dotted`
+  (`core/util/factory.py:26`), raising `AKConfigError` otherwise.
+  - This is what makes local-in-dev / S3-in-prod a one-environment-variable change without the KB
+    tier gaining an `AKConfig` section (see [Decisions](#decisions) 1).
+- Stores take **explicit constructor parameters and never read `AKConfig`**, matching the shared-driver
+  and transport rules.
+
+### Representation layer — OKF parsing
+
+- New `knowledgebase/okf/` package holding the format only. It takes `bytes`/`str` in and returns
+  objects; it never touches a `DocumentStore` or a network.
+- `OKFConcept`: the parsed document — `path` (its identity), `type` (the only required frontmatter
+  field), and the identity / provenance / trust / lifecycle / computation families, plus the markdown
+  body and its outbound links.
+- `OKFBundle`: the parsed tree — concepts keyed by path, reserved files (`index.md`, `log.md`), the
+  declared `okf_version` from the bundle-root `index.md` frontmatter, and a **diagnostics list**.
+- YAML frontmatter is parsed with `pyyaml`, already a **core** dependency
+  (`ak-py/pyproject.toml`), so a local-filesystem OKF backend needs **no optional extra at all**.
+- **Tolerant by specification** — the research is explicit that a strict OKF reader is a
+  non-conformant one (`research/okf-format-survey.md` §5). Concretely:
+  - A file that fails to parse, or lacks a non-empty `type`, is **skipped with a diagnostic**; the
+    bundle still loads.
+  - Unknown frontmatter keys, unknown `type` values, missing optional fields, a missing `index.md`,
+    and broken links are all carried through, never rejected.
+  - A bare `verified` mapping is normalised to a one-element list.
+  - **v0.2 only** (see [Decisions](#decisions) 5). No v0.1 translation: a v0.1 `timestamp` key or a
+    body `# Citations` list is carried through as an unknown key / ordinary body text, never mapped
+    onto `generated` / `sources`. A bundle declaring any other `okf_version` still loads; the
+    mismatch is recorded as a diagnostic, never a rejection.
+  - Diagnostics are **surfaced**, not swallowed: exposed on the bundle, logged at `warning` on load,
+    and reported through `get_description()`.
+- Trust tier is derived only from `verified` — absent → `unverified`; present with no `human:` actor →
+  `machine-confirmed`; present with a `human:` actor → `human-reviewed`. Staleness is derived only
+  from `stale_after`. Both are **advisory signals attached to every returned record**; nothing is
+  ever filtered out on their basis, and that must be asserted by a test.
+- Links are extracted in both specified forms — bundle-absolute (`/tables/x.md`) and relative
+  (`./x.md`) — resolved to bundle-relative paths and attached as `metadata["links"]`, so an agent can
+  traverse the graph with `fetch`.
+
+### `DocumentKnowledgeBase` and `OKFManager`
+
+- `DocumentKnowledgeBase` (abstract, `knowledgebase/document.py`) is the **only** new intermediate
+  base class, and it exists because it carries real shared behavior for any path-addressed
+  collection: holding the `DocumentStore`, normalising and validating paths, mapping
+  `FileNotFoundError` to an empty result, and folding `store.writable` into its capabilities.
+- `OKFManager(store: DocumentStore, name: str = "", description: str | None = None)` composes the
+  store with the OKF parser. It declares
+  `kinds=["document"], search=True, search_mode="lexical", fetch=True, browse=True,
+  writable=store.writable, derives_schema=True`.
+  - `fetch(ids)` — bundle paths in, concept records out. The natural companion to `metadata["links"]`.
+  - `browse(path)` — directory listing; a bundle-root call returns `index.md`'s listing when present
+    and a derived listing when it is not.
+  - `search(query, limit)` — **lexical**, over frontmatter (`title`, `description`, `tags`, `type`)
+    and body text, ranked by field-weighted term overlap. Declared as `lexical` precisely so no
+    caller mistakes it for embedding search.
+  - `write(records)` — emits **conformant** concept documents: a non-empty `type`, and
+    `generated: {by, at}` stamped with the writing actor in the `<producer>/<version>` convention.
+    Kept because producing OKF is the format's intended agent workflow, not only consuming it
+    (`research/okf-format-survey.md` §8).
+  - `format_results` renders `id`, `title`, `type`, trust tier, and a staleness marker, so routing
+    information reaches the agent rather than being flattened away.
+- **Bundle manifest and cost.** `connect()` walks the store once and holds a parsed manifest in
+  process.
+  - Without it, one `browse` or `search` over an S3 bundle is one `list` plus one `get` per object,
+    on every agent tool call.
+  - `refresh_seconds` **defaults to 300**: the manifest re-walks lazily on the first access after the
+    interval has elapsed, so a bundle rewritten by a separate producer pipeline is picked up without a
+    restart. `reload()` forces an immediate re-walk; `refresh_seconds=None` disables automatic
+    refresh for a bundle known to be immutable.
+  - Stated consequence: an edit made underneath a running process is seen at most `refresh_seconds`
+    later, and the re-walk cost lands on whichever agent tool call crosses the boundary. This is the
+    deliberate trade and must be documented on the backend.
+  - Bodies of large bundles are read lazily per concept; frontmatter is parsed eagerly, because
+    schema derivation and search ranking both need it.
+
+### Agent surface — `KnowledgeBuilder`
+
+- The four existing tools keep their names and signatures: `get_schemas`, `read_kb`, `write_kb`,
+  `get_all_kb_descriptions`.
+- Two new capability-gated tools:
+  - `fetch_kb(backend: str, ids: str) -> str` — comma-separated ids.
+  - `browse_kb(backend: str, path: str = "", limit: int = 50) -> str`.
+  - Each is included in `build()`'s output **only when at least one registered backend declares that
+    capability**, so a vector-only application's tool list is unchanged.
+  - Routing a call at a backend that does not declare the capability returns an actionable string
+    naming the backends that do — matching `read_kb`'s existing error-to-string behavior
+    (`knowledgebuilder.py:118-119,128-130`), never an exception into the framework.
+- `write_kb` stops emitting Neo4j's `cypher_query` / `cypher_params` keys
+  (`knowledgebuilder.py:157-166`); it emits the generic `query` / `params` only.
+  - `Neo4jManager.write` reads `query`/`params` first and falls back to `cypher_query`/`cypher_params`
+    (`neo4j.py:120-121`), so a caller writing records by hand in the old shape still works.
+- `get_schemas` gains the same per-backend `try/except` its sibling `get_all_kb_descriptions` already
+  has (`knowledgebuilder.py:185-187`), reporting the failing backend inline instead of failing the
+  whole call.
+- Semantic-map placeholder resolution (`knowledgebuilder.py:76-89`) applies to `fetch_kb` ids and
+  `browse_kb` paths as well as queries, so an OKF bundle root can be an environment-swappable token.
+
+### Extensibility
+
+- Adding a KB type requires: subclass `KnowledgeBase` (or `DocumentKnowledgeBase`), declare
+  `KnowledgeCapabilities`, override the operations declared. No change to `KnowledgeBuilder`, the
+  tools, or any framework adapter.
+- Adding a **storage** backend for an existing representation requires only a `DocumentStore`
+  subclass — an HTTP-served or git-backed OKF bundle is a store, not a new KB.
+- `knowledgebase/testing.py` ships `KnowledgeBaseContract` and `DocumentStoreContract`, reusable
+  suites in the `SandboxProviderContract` (`sandbox/testing.py:130`) / `QueueTransportContract` shape.
+  `KnowledgeBaseContract` asserts, for any backend: declared capabilities match implemented
+  operations; undeclared operations raise `KnowledgeCapabilityError`; records carry `id` when
+  `fetch` is declared; unknown metadata keys round-trip; `read()` routes to the declared primitive.
+- `knowledgebase/__init__.py` gains **lazy** exports via PEP 562 `__getattr__` (the
+  `deployment/aws/__init__.py` pattern) for `KnowledgeBase`, `KnowledgeBuilder`,
+  `KnowledgeCapabilities`, `Record`, and the errors — fixing the import documented at
+  `docs/docs/core-concepts/overview.md:353` without making `chromadb`/`neo4j`/`trino`/`boto3` eager.
+
+### Security
+
+- **Path containment**: every agent-supplied id or path reaching `fetch`/`browse`/`write` is
+  normalised and rejected if it escapes the bundle root — `..` segments, absolute paths, and symlinks
+  that resolve outside `LocalDocumentStore.root`. Rejection is an error result, not a traversal.
+- **No network fetch of OKF reference fields**: `resource`, `sources[].resource`, and `computation`
+  values that are absolute URLs are returned to the agent as data and never dereferenced by the KB
+  layer, matching the multimodal hook's stance on remote references
+  (`core/multimodal/hooks.py:41,344`).
+- Concept body text is untrusted content authored by whoever produced the bundle. It is returned as
+  data; nothing in the KB layer acts on instructions found inside a concept.
+
+### Error handling
+
+- Missing/unreadable document → empty result plus a logged warning; never a traversal or a raise into
+  the framework.
+- Malformed concept → skipped with a diagnostic; the bundle still loads (specification requirement).
+- Missing store configuration (no bucket, unreadable root) → `ValueError` at construction, matching
+  `StarburstManager.connect`'s missing-config behavior (`starburst.py:102`).
+- Missing `boto3` for `s3://` → `ImportError` naming the `aws` extra, via `require_extra`
+  (`core/util/factory.py:50`).
+- Unresolvable `from_uri` value → `AKConfigError`.
+- Undeclared operation → `KnowledgeCapabilityError`, caught at the tool boundary and returned as an
+  actionable string.
+
+## Migration and behavioural changes
+
+Each is intentional; each needs a test.
+
+1. `KnowledgeBase.read` becomes concrete, delegating to `query()`/`search()`. Existing overrides in
+   `ChromaManager`, `Neo4jManager`, `StarburstManager` are **renamed** to `search`/`query`/`query`
+   respectively; the base alias preserves `read()` for every caller. A third-party subclass that
+   overrides `read()` is unaffected.
+2. `StarburstManager.write` raises `KnowledgeCapabilityError` instead of `NotImplementedError`
+   (`starburst.py:141`). `KnowledgeCapabilityError` does **not** subclass `NotImplementedError`, so
+   any caller catching the old type must be updated — in-tree there are none.
+3. `schema()` no longer raises when `add_schema()` was skipped **and** the backend derives its own
+   (`base.py:57-58`). For the three existing backends, all of which declare
+   `derives_schema=False`, behavior is unchanged.
+4. `schema()` output gains `"capabilities"`. This changes the JSON `get_schemas` returns to the
+   agent — additive, but it is a prompt-visible change.
+5. `write_kb` no longer writes `cypher_query`/`cypher_params` into record metadata
+   (`knowledgebuilder.py:157-166`). Neo4j reads the generic keys with the old keys as fallback, so
+   agent-issued writes are unaffected; **records already stored by Chroma carry the dead keys and are
+   not migrated**.
+6. `get_schemas` degrades per backend instead of failing the call.
+7. `build()` may return six callables rather than four, when a registered backend declares `fetch`
+   or `browse`.
+8. `agentkernel.knowledgebase` exports names for the first time — additive; the documented import
+   starts working.
+
+**Non-changes**, to be asserted: `Record` stays `Mapping[str, Any]`; `read`/`write` signatures;
+the four existing tool names and signatures; `KnowledgeBuilder.__init__`'s `backends` +
+`semantic_map` signature; `add_schema`/`format_results`/`close`; no framework adapter changes; no
+`AKConfig` section added; every existing example (`examples/cli/knowledgebase/openai/*`) runs
+unmodified.
+
+## Deviations from the proposed class diagram
+
+The input diagram's storage half — `OKFManager o-- OKFStorage`, `LocalOKFStorage` / `S3OKFStorage` —
+is adopted as-is in substance. Two changes:
+
+- **`VectorKB` / `StructuredKB` / `FileSystemKB` become `capabilities.kinds`, not base classes.**
+  - The diagram has `Neo4jManager` inheriting from both `VectorKB` and `StructuredKB`. That is a
+    diamond whose only purpose is to say "this backend is two things" — which a declared list says
+    directly, and which today's `Neo4jManager` does not even need, since it is Cypher-only
+    (`neo4j.py:125-146`) with no vector index.
+  - `AGENTS.md` forbids exactly this: *"Don't invent a new intermediate abstraction 'for consistency'
+    across adapters… forcing uniformity across adapters is itself an opinion the architecture
+    avoids."* (`AGENTS.md:67-69`) Marker classes carrying no behavior are that abstraction.
+  - The repo has already answered "what can this backend do?" with declared data rather than type
+    identity, in `SandboxCapabilities` (`sandbox/model.py:33-48`).
+  - The taxonomy is not lost — it becomes stronger, because `kinds` reaches the agent through
+    `get_schemas()` where an inheritance edge never could.
+  - `DocumentKnowledgeBase` **is** kept as a base class, because unlike the other three it carries
+    real shared implementation (store composition, path containment, error mapping) that a second
+    document-shaped KB would otherwise duplicate.
+- **`OKFStorage` → `DocumentStore`.** The store reads bytes at paths; it has no OKF knowledge, and
+  naming it for one format would make it look wrong to reuse for the next path-addressed
+  representation. `OKFManager` keeps the `*Manager` suffix of its siblings for discoverability.
+
+## Non-goals
+
+- **Executing Attested Computations.** `type: Attested Computation` concepts are read like any other
+  concept; the executor/attester workflow runs arbitrary code and belongs to the sandbox capability
+  (`research/okf-format-survey.md` §7).
+- **Embedding an OKF bundle into a vector store.** Semantic search over a bundle is achieved by
+  composing an OKF backend with a vector backend in one `KnowledgeBuilder` — not by giving
+  `OKFManager` an embedder.
+- **An OKF authoring/enrichment agent.** `write` emits conformant documents; the producer-side
+  pipeline is a separate change.
+- **A `knowledgebase` block in `AKConfig`.** Backends stay application-constructed, as today.
+- Bundle-level concurrency control, versioning, or locking on write.
+- Changing any framework adapter, `Runtime`, `Session`, or the system-tool factory. Knowledge-base
+  tools remain application-bound through `KnowledgeBuilder.build()`.
+- Migrating metadata already written by the current `write_kb` (item 5 above).
+- Rewriting `semantic_map`, the KB router pattern, or the existing examples.
+
+## Decisions
+
+Resolved with the maintainer on 2026-08-31. The requirements above already reflect them.
+
+1. **Config — no `AKConfig` section.** Applications construct the backend and its `DocumentStore`
+   explicitly, as they do today. `DocumentStore.from_uri` keeps local-in-dev / S3-in-prod a one-string
+   change; reading that string from the environment stays the application's job.
+2. **`kinds` — open `list[str]`.** `vector`, `structured`, `graph`, `document` are documented
+   conventional values, not a closed enum. Extensibility wins over agent-side routability, and the
+   values are advisory anyway — routing is driven by the boolean capability flags and
+   `get_description()`, not by `kinds`.
+3. **Record typing — `KnowledgeRecord` as a `TypedDict`.** Reserved keys get a documented home,
+   `Record` stays `Mapping[str, Any]`, and no existing backend or user subclass is invalidated. The
+   "a `fetch`-capable backend must set `id`" rule is enforced by `KnowledgeBaseContract`, not by
+   runtime validation.
+4. **Manifest refresh — lazy automatic refresh, `refresh_seconds` default 300.** The manifest re-walks
+   on the first access after the interval elapses; `reload()` forces one immediately;
+   `refresh_seconds=None` opts out for an immutable bundle. Chosen so an S3 bundle rewritten by a
+   separate producer pipeline is picked up without a restart.
+5. **OKF version — v0.2 only.** No v0.1 read translation and no v0.1 writes. A v0.1 bundle still
+   *loads*, because the conformance rules forbid rejecting a concept for unknown frontmatter keys —
+   but `timestamp` and a body `# Citations` list are carried through as unrecognised content rather
+   than mapped onto `generated` / `sources`, and a declared `okf_version` other than `0.2` is recorded
+   as a bundle diagnostic.
+6. **Verification gate — stands.** Every `[SPEC]`-marked claim in `research/okf-format-survey.md` must
+   be re-checked verbatim against the OKF **v0.2** specification text before `spec.md` fixes
+   conformance behavior.

--- a/docs/specs/553-okf-knowledge-bases/design.md
+++ b/docs/specs/553-okf-knowledge-bases/design.md
@@ -484,7 +484,9 @@ classDiagram
     (`neo4j.py:120-121`), so dropping those keys without touching it would call `_run(None, {})` on
     every agent-issued write. It is changed to read `query`/`params` first and fall back to
     `cypher_query`/`cypher_params`, keeping hand-written old-shape records working, and to skip a
-    record carrying neither with a logged warning rather than handing `None` to the driver.
+    record carrying neither with a logged warning rather than handing `None` to the driver. The skips
+    are reported by raising `KnowledgeError` once the batch is through, so the writable records still
+    land but a write that stored nothing is not reported to the agent as a success.
 - `get_schemas` gains the same per-backend `try/except` its sibling `get_all_kb_descriptions` already
   has (`knowledgebuilder.py:185-187`), reporting the failing backend inline instead of failing the
   whole call.
@@ -602,7 +604,11 @@ Each is intentional; each needs a test.
 12. `Neo4jManager.write` reads the generic `query`/`params` metadata keys, falling back to
     `cypher_query`/`cypher_params`, and skips a record carrying neither with a logged warning instead
     of calling the driver with `None` (`neo4j.py:118-123`). Required by item 5: `write_kb` no longer
-    emits the `cypher_*` keys, and the fallback is what keeps old-shape records working.
+    emits the `cypher_*` keys, and the fallback is what keeps old-shape records working. Once the batch
+    is through, a `KnowledgeError` names what was stored and what was not, so a text-only
+    `write_kb("neo4j", …)` reports a failure instead of a success for a write that stored nothing —
+    without it, the skip would turn today's hard failure (`_run(None, {})` erroring) into a silent one.
+    `spec.md` behavioural change 17.
 13. `KnowledgeBase.__init__` requires a `capabilities` argument (`name` stays optional). A
     third-party subclass calling `super().__init__()` with no arguments must pass one — the only
     signature in this change that is not backward compatible, and the reason capability declaration is

--- a/docs/specs/553-okf-knowledge-bases/plan.md
+++ b/docs/specs/553-okf-knowledge-bases/plan.md
@@ -1,0 +1,227 @@
+# #553: Open Knowledge Format support and the knowledge-base architecture refactor — Implementation Plan
+
+Orders [`spec.md`](spec.md) into iterations. Every component in that document appears in exactly one
+iteration below; nothing here restates its detail — each step cites the spec section that fixes it.
+
+Two conventions that shape the ordering:
+
+- **Unit tests land with the code they cover**, per `ak-dev-testing-conventions`, so every iteration is
+  independently verifiable. Iteration 8 adds only what cannot be written earlier: the reusable
+  `KnowledgeBaseContract`, its run against every backend, and the scale envelope.
+- **`KnowledgeBase.__init__` requiring `capabilities` (behavioural change 13) is what couples the early
+  iterations.** The reshaped ABC and the three existing backends must land together — the moment the
+  base takes a required argument, `ChromaManager()` / `Neo4jManager()` / `StarburstManager()` raise
+  `TypeError`. That is iteration 2, and it is deliberately the largest.
+
+Every iteration ends green on `cd ak-py && uv run pytest -k knowledgebase` and on
+`make lint-check-all` (the command `code-quality.yml` runs). Expect unrelated e2e failures on a full
+local `pytest` without CI credentials (`AGENTS.md:103-108`).
+
+## Iteration 1: Capability model and errors
+
+- **Goal:** `KnowledgeCapabilities`, the two record `TypedDict`s, and the three error types exist and
+  are tested. Pure addition — no existing module imports them yet, so the branch is unchanged in
+  behavior.
+- **Files:** `knowledgebase/model.py` (new), `knowledgebase/errors.py` (new),
+  `ak-py/tests/test_knowledgebase_model.py` (new).
+- **Steps:**
+  1. `model.py` — `KnowledgeCapabilities` with the nine fields, plus `KnowledgeMetadata` /
+     `KnowledgeRecord` as `total=False` `TypedDict`s (spec § `knowledgebase/model.py`). No cross-field
+     validator on the model: both invariants belong to `KnowledgeBase.__init__`, which knows the
+     backend name.
+  2. `errors.py` — `KnowledgeError`, `KnowledgeCapabilityError` (the `sandbox/errors.py:20-39` shape,
+     *not* subclassing `NotImplementedError`), `KnowledgePathError` (spec § `knowledgebase/errors.py`,
+     addition A).
+- **Verify:** `uv run pytest tests/test_knowledgebase_model.py` — defaults, `model_dump()` shape, and
+  that constructing a `KnowledgeCapabilities` alone never validates.
+
+## Iteration 2: The reshaped ABC and the three existing backends
+
+- **Goal:** the capability contract is live end to end for the backends that exist today. `read()` is
+  concrete and routes; `search`/`query`/`fetch`/`browse`/`write` are optional; `schema()` derives and
+  carries `capabilities`; Starburst's `schema` attribute/method collision is fixed.
+- **Files:** `knowledgebase/base.py`, `knowledgebase/chroma.py`, `knowledgebase/neo4j.py`,
+  `knowledgebase/starburst.py`, `ak-py/tests/test_knowledgebase_base.py` (new), and the
+  `validate_capabilities` half of `ak-py/tests/test_knowledgebase_model.py`.
+- **Steps:**
+  1. `base.py` — `__init__(capabilities, name=None)`, module-level `validate_capabilities`, the five
+     optional operations, concrete `read()` routing on `capabilities.query`, `_derived_schema()` +
+     relaxed `schema()` guard with `capabilities` written last and unoverridable, and the `fetch`-gated
+     `format_results` prefix (spec § `knowledgebase/base.py` and its two subsections; addition G).
+     `read`/`write` stop being abstract; `backend_name`/`connect`/`get_description` stay abstract.
+  2. `chroma.py` — declare `kinds=["vector"], search=True, search_mode="semantic", writable=True`;
+     rename `read` → `search`.
+  3. `neo4j.py` — declare `kinds=["graph","structured"], query=True, query_language="cypher",
+     writable=True`; rename `read` → `query` with the first parameter `statement`; make `write` read
+     `metadata["query"]`/`params` **with the `cypher_*` fallback** and skip a record carrying neither.
+     The fallback lands **before** iteration 3 drops the `cypher_*` emission, so neither iteration
+     leaves agent-issued Neo4j writes broken.
+  4. `starburst.py` — declare `kinds=["structured"], query=True, query_language="sql",
+     writable=False`; move `self.schema` → `self.db_schema` and update its three readers
+     (`starburst.py:111,116,204`) leaving the `schema=` constructor keyword alone; rename `read` →
+     `query`; `write` raises `KnowledgeCapabilityError`. Leave `_execute`'s `[]`-on-failure as is
+     (spec § `StarburstManager`).
+- **Verify:** `uv run pytest tests/test_knowledgebase_base.py tests/test_knowledgebase_model.py`, plus
+  the four existing examples still constructing their backends — behavioural changes 1-4, 9-11, 14-16
+  all land here and each has an assertion.
+
+## Iteration 3: `KnowledgeBuilder` — capability-gated tools
+
+- **Goal:** the agent surface reflects the capability model: up to seven tools, gated on the registered
+  set, with generic write metadata.
+- **Files:** `knowledgebase/knowledgebuilder.py`, `ak-py/tests/test_knowledgebase_builder.py` (new).
+- **Steps:**
+  1. Add `search_kb`, `fetch_kb`, `browse_kb`, appended in that order after the existing four, each
+     emitted only on its gate (`search_kb` needs a backend declaring **both** `search` and `query`);
+     capability mismatches return the actionable string, never an exception (spec §
+     `knowledgebase/knowledgebuilder.py`).
+  2. Extend semantic-map resolution to `search_kb` queries, `fetch_kb` ids (per segment, after the `,`
+     split) and `browse_kb` paths.
+  3. `get_schemas` gains the per-backend `try/except` its sibling already has; `write_kb` stops setting
+     `cypher_query`/`cypher_params`; capability reads go through `getattr(backend, "capabilities",
+     None)` with a warning for a backend that never called `super().__init__()`.
+- **Verify:** `uv run pytest tests/test_knowledgebase_builder.py` — the riskiest consumer, so the
+  gating matrix, tool order, and the `write_kb` metadata assertion are all here (behavioural changes
+  5-7).
+
+## Iteration 4: Storage axis — `DocumentStore`
+
+- **Goal:** bytes at paths, containment enforced in one place, local and S3 stores interchangeable
+  through `from_uri`. Nothing consumes it yet.
+- **Files:** `knowledgebase/store/{__init__,base,local,s3}.py` (new), `knowledgebase/testing.py` (new —
+  `DocumentStoreContract` only), `ak-py/tests/test_knowledgebase_stores.py` (new).
+- **Steps:**
+  1. `store/base.py` — the ABC, `normalise_relative` called by every entrypoint and by every path
+     `list()` emits, `read_prefix_bytes` with its default, `write_bytes` refusal on a non-writable
+     store, and `from_uri`'s five branches including the mandatory `python:` discriminator (spec §
+     `knowledgebase/store/`; addition C).
+  2. `store/local.py` — `realpath` root with a `ValueError` on a non-directory, `writable=None`
+     probing, traversal-time containment (`os.walk(followlinks=False)` + `commonpath`), and
+     `sorted()` global lexicographic `list()`.
+  3. `store/s3.py` — `require_extra("aws", …)`, injectable client, paginated `list`, `NoSuchKey`/404 →
+     `FileNotFoundError`, ranged-GET `read_prefix_bytes`, declared `writable`.
+  4. `testing.py` — `DocumentStoreContract` in the `SandboxProviderContract` (`sandbox/testing.py:130`)
+     shape. The file imports `pytest`, so it is excluded from every lazy export map.
+- **Verify:** `uv run pytest tests/test_knowledgebase_stores.py` — the contract over a real `tmp_path`
+  and a fake boto3 client, plus the containment matrix and the `a/z.md` vs `ab/b.md` ordering case.
+
+## Iteration 5: Representation axis — OKF parsing
+
+- **Goal:** `bytes`/`str` in, `OKFConcept`/`OKFBundle` out, tolerant by specification. No store, no
+  network.
+- **Files:** `knowledgebase/okf/{__init__,model,parser}.py` (new),
+  `ak-py/tests/test_knowledgebase_okf_parser.py` (new).
+- **Steps:**
+  1. `okf/model.py` — `TrustTier`, `OKFDiagnostic`, `OKFConcept`, `OKFBundle`, and the exhaustive
+     diagnostic-code table (spec § `okf/model.py`).
+  2. `okf/parser.py` — frontmatter split (`yaml.safe_load` only), the tolerance rules, trust from
+     `verified` alone, staleness from `stale_after` against an injected `now`, and link extraction in
+     both specified forms (spec § `okf/parser.py`).
+  3. Reserved-file rules: `index.md` and `log.md` at **every** level; root-only `okf_version`
+     frontmatter; an `index.md` elsewhere carrying frontmatter gets a diagnostic and is still used
+     (spec § `index.md` and `log.md` handling — verification-gate outcome 2).
+- **Verify:** `uv run pytest tests/test_knowledgebase_okf_parser.py` — every diagnostic code reachable,
+  the v0.2-only assertions (`timestamp` → `extra`, `# Citations` stays body text), and the test that
+  fails if the module pulls in `urllib`/`httpx` or `knowledgebase.store`.
+
+## Iteration 6: `DocumentKnowledgeBase` and `OKFManager`
+
+- **Goal:** OKF is a working backend — `search`/`fetch`/`browse`/`write` over a `DocumentStore`, with
+  the manifest, its refresh, and write-through visibility.
+- **Files:** `knowledgebase/document.py` (new), `knowledgebase/okf/manager.py` (new),
+  `ak-py/tests/test_knowledgebase_okf_manager.py` (new).
+- **Steps:**
+  1. `document.py` — store composition, `store.writable` folded in with `and`, `_read_document`'s
+     `FileNotFoundError` → `None` mapping, `close()` delegation (spec § `knowledgebase/document.py`).
+  2. `OKFManager.__init__` — capabilities from the injected store, producer resolved once via
+     `importlib.metadata` with the `agentkernel/unknown` fallback.
+  3. The manifest: bounded `read_prefix_bytes` walk with a full-read fallback, retained frontmatter +
+     `body_tokens`, `max_concepts` truncation over the store's lexicographic order (spec § Manifest;
+     addition F).
+  4. `_ensure_manifest` — blocking initial load, non-blocking refresh under `threading.Lock`,
+     whole-object swap, failed refresh serving stale and resetting the clock, `reload()` (spec §
+     Refresh and concurrency).
+  5. The five operations plus `_derived_schema`, `get_description` (diagnostics surfaced), and the
+     `format_results` override (spec § Operations). `write()` is write-through and refuses a `,` in a
+     bundle path.
+- **Verify:** `uv run pytest tests/test_knowledgebase_okf_manager.py` — ranking determinism,
+  browse-at-`tables/`, write-through with `refresh_seconds=None`, one walk under two concurrent
+  boundary-crossing callers, and that nothing is ever filtered on trust or staleness.
+
+## Iteration 7: Public exports and the OKF example
+
+- **Goal:** the documented import works, optional SDKs stay lazy, and the whole capability-gated tool
+  set is demonstrated end to end.
+- **Files:** `knowledgebase/__init__.py` (rewritten), `ak-py/tests/test_knowledgebase_exports.py`
+  (new), `examples/cli/knowledgebase/openai/okf/` (new).
+- **Steps:**
+  1. `__init__.py` — the PEP 562 `_LAZY_EXPORTS` map of `deployment/aws/__init__.py:13-66`, with the
+     `TYPE_CHECKING` mirror block. The three SDK-backed managers and `testing.py` are deliberately not
+     exported (spec § `knowledgebase/__init__.py`; behavioural change 8).
+  2. The example, in its siblings' shape (`build.sh`, `demo.py`, `demo_test.py`, `__init__.py`,
+     `pyproject.toml`, `README.md`) plus the checked-in `bundle/` — root and `tables/` `index.md`, a
+     `log.md`, three trust tiers, an unknown `type`, and one malformed file. `demo.py` calls no
+     `add_schema()` (that is what `derives_schema=True` buys) and registers a `semantic_map` for the
+     bundle root. `pyproject.toml` follows the sibling convention: runtime `agentkernel[cli,openai]`,
+     dev group `agentkernel[test]`, and **no KB extra** — `pyyaml` is core.
+  3. `README.md` walks `browse_kb` → `fetch_kb` → `search_kb` against real bundle paths.
+- **Verify:** `uv run pytest tests/test_knowledgebase_exports.py` (every `__all__` name resolves;
+  `chromadb`/`neo4j`/`trino`/`boto3` stay out of `sys.modules`; the `overview.md:353` import works
+  verbatim), then `./build.sh local && uv run pytest` inside the example.
+
+## Iteration 8: Contract suite and scale envelope
+
+- **Goal:** the contract every backend is held to is reusable and actually run, and the declared
+  10,000-concept envelope is enforced by CI rather than asserted in prose.
+- **Files:** `knowledgebase/testing.py` (extended), `ak-py/tests/test_knowledgebase_contract.py` (new),
+  `ak-py/tests/test_knowledgebase_okf_envelope.py` (new).
+- **Steps:**
+  1. `testing.py` — `KnowledgeBaseContract` and `FakeKnowledgeBase` alongside the existing
+     `DocumentStoreContract`; neither contract class is named `Test*`.
+  2. `test_knowledgebase_contract.py` — the contract run against `FakeKnowledgeBase` in four capability
+     shapes, `OKFManager` over a real local bundle, and the three existing backends with
+     `chromadb.PersistentClient`, `neo4j.GraphDatabase.driver`, and `trino.dbapi.connect`
+     monkeypatched. The `schema()`-is-callable assertion is the regression guard for the Starburst
+     collision.
+  3. `test_knowledgebase_okf_envelope.py` — a generated 10,000-concept bundle; all 10,000 kept, and
+     `tracemalloc` allocations attributable to `_walk()` under 50 MB (not RSS).
+- **Verify:** `cd ak-py && uv run pytest -k knowledgebase` green, then `make lint-check-all`.
+
+## Iteration 9: Sync docs and skills
+
+Each surface below was checked against the branch; line numbers are where the stale text is today.
+
+- **Docs:**
+  - `docs/docs/advanced/knowledge-bases.md:15` (`### KnowledgeBase`) — the five-operation set replaces
+    the `read`/`write` pair; `KnowledgeCapabilities`; `OKFManager` in the backend list.
+  - same file `:47` (`## KnowledgeBuilder and Tools`) — the three new tools and their gating.
+  - same file, **new section** — the OKF backend, `DocumentStore` local-vs-S3, `from_uri`, and the
+    `refresh_seconds`/`max_concepts` cost statement (one ranged GET per concept per refresh per pod).
+  - same file `:203-235` (`### Minimal implementation`) — **required, not cosmetic**: the example
+    subclass defines no `__init__`, so it stops constructing under behavioural change 13 (spec
+    deviation E).
+  - same file `:253-260` (`### Optional overrides`) — add `_derived_schema()`; note `schema()` now
+    always carries `capabilities`.
+  - `docs/docs/core-concepts/overview.md:351-358` — the documented import starts working; the
+    `read`/`write` bullet list becomes the operation set.
+  - Both pages call out the two prompt-visible migrations: `schema()` gaining `"capabilities"`, and
+    `StarburstManager.schema` → `db_schema`.
+- **Skills:**
+  - `.agents/skills/ak-dev-new-knowledgebase-integration/SKILL.md` — the heaviest rewrite: step 2's
+    `super().__init__()` at `:52` now needs `capabilities=`; step 3 "Record Contract" (`:83`) predates
+    `KnowledgeMetadata`; step 4 (`:92-98`) tells authors to raise `NotImplementedError` for a read-only
+    backend; and there is no capability-declaration or `DocumentStore` step at all. Add both, plus the
+    `KnowledgeBaseContract` requirement to step 9 (`:149`) and the checklist (`:174`).
+  - `.agents/skills/ak-dev-architecture/SKILL.md:520-521` — the `KnowledgeBase` member list and the
+    four-tool `KnowledgeBuilder` line; `:714-716` — the directory tree gains `model.py`, `errors.py`,
+    `document.py`, `store/`, `okf/`, `testing.py`.
+  - `ak-py/src/agentkernel/skills/ak-add-capabilities/SKILL.md:353-419` — the knowledge-base capability
+    section: the new tools, and OKF as a backend option. Its custom-backend pointer at `:418-419` stays
+    valid.
+- **Verified as needing no update:** no `AKConfig` section, so nothing under `ak-deployment/` or the
+  Helm chart changes; no framework adapter, `Runtime`, or `Session` surface moves; no existing test
+  file references the knowledge-base tier (grep over `ak-py/tests/` and `e2e/`), so **no patch target
+  moves anywhere in the suite**; `.agents/skills/ak-dev-testing-conventions` needs no change — the two
+  new contract suites follow the pattern it already documents.
+- **Verify:** run the `ak-dev-sync-docs-from-branch` and `ak-dev-sync-skills-from-branch` flows before
+  merge to catch any surface this list missed, then `make lint-check-all`.

--- a/docs/specs/553-okf-knowledge-bases/research/okf-format-survey.md
+++ b/docs/specs/553-okf-knowledge-bases/research/okf-format-survey.md
@@ -1,0 +1,158 @@
+# Open Knowledge Format (OKF) — format survey
+
+Supporting research for `../design.md` (issue #553). Captures what OKF is, what it requires of a
+consumer, and which of its properties drive the AK design decisions.
+
+**Verification status.** The v0.2 specification and the announcement blog were read on 2026-08-31 via
+web fetch, and the summaries below are that reading, not a verbatim transcription. Every normative
+statement marked **[SPEC]** must be re-checked against the specification text verbatim before it is
+implemented — the design's conformance requirements are only as good as this re-check.
+
+Sources:
+- Announcement: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing
+- Specification + reference implementations: https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf
+
+## 1. What OKF is
+
+- A vendor-neutral, open **format** for curated, agent-consumable knowledge. Explicitly *not* a
+  platform, an SDK, an ontology, or a query language.
+- It formalizes the "LLM-wiki" pattern: knowledge a team already writes in markdown, given just
+  enough structure that an agent can navigate it mechanically.
+- Current published version is **v0.2**; v0.1 bundles remain consumable with fallbacks.
+
+## 2. Physical shape
+
+A bundle is a directory tree of markdown files:
+
+```
+sales/
+├── index.md                # reserved: directory listing / progressive disclosure
+├── log.md                  # reserved: chronological change history
+├── datasets/
+│   ├── index.md
+│   └── orders_db.md
+├── tables/
+│   ├── orders.md
+│   └── customers.md
+└── references/             # conventional: mirrored external material, scripts, code
+```
+
+- **The file path is the concept's identity.** `/tables/orders.md` *is* the id. There is no separate
+  id field, and nothing outside the path is authoritative.
+- `index.md` and `log.md` are **reserved filenames [SPEC]** — they are not concept documents.
+- Distribution is by ordinary means: a git repo, a tarball, a mounted directory, an object-store
+  prefix. Nothing in the format assumes a database.
+
+## 3. Concept documents
+
+YAML frontmatter + markdown body.
+
+```yaml
+---
+type: BigQuery Table                       # the ONLY required field [SPEC]
+title: Orders
+description: One row per completed customer order.
+resource: https://console.cloud.google.com/bigquery?p=acme&d=sales&t=orders
+tags: [sales, revenue]
+status: stable                             # draft | stable (default) | deprecated
+stale_after: 2026-12-01T00:00:00Z
+generated: { by: reference_agent/gemini-2.5-pro, at: 2026-05-28T14:30:00Z }
+verified:
+  - { by: "human:jsmith", at: 2026-06-02T09:00:00Z }
+sources:
+  - { id: bq_meta, resource: "https://…", title: "BigQuery INFORMATION_SCHEMA" }
+---
+
+# Schema
+| Column | Type | Description |
+|--------|------|-------------|
+| `customer_id` | STRING | FK to [customers](/tables/customers.md). |
+```
+
+Frontmatter families:
+
+| Family | Fields | Purpose |
+|---|---|---|
+| Identity | `type` (required), `title`, `description`, `resource`, `tags` | what the concept is |
+| Provenance | `sources[]` (`resource` required; `id`, `title`, `author`, `usage_count`, `last_modified`) | what it was derived from |
+| Trust | `generated: {by, at}`, `verified: [{by, at}]` | who produced/checked it |
+| Lifecycle | `status`, `stale_after` | whether it should still be believed |
+| Computation | `runtime`, `parameters`, `computation`, `executor`, `attester` | only for `type: Attested Computation` |
+
+- **Actor convention [SPEC]**: `<producer>/<version>` for agents, `human:<id>` for people,
+  `process:<id>` for automation. Consumers detect human review by the `human:` prefix.
+- **Trust tiers [SPEC]** derive from `verified`: absent → *unverified*; present with no `human:`
+  actor → *machine-confirmed*; present with a `human:` actor → *human-reviewed*. Advisory signals,
+  never grounds for rejection.
+- Conventional body headings with defined meaning: `# Schema`, `# Examples`, `# Computation`.
+- Per-claim attribution uses markdown footnotes keyed to `sources[].id`.
+
+## 4. The graph is markdown links
+
+Relationships are ordinary markdown links, in two forms **[SPEC]**:
+
+- **Bundle-absolute**: `[customers](/tables/customers.md)` — resolved from the bundle root.
+- **Relative**: `[sibling](./other.md)`.
+
+Link *semantics* live in the surrounding prose, not in the link. There is no typed edge, no
+relationship vocabulary, and no graph database. Path-valued frontmatter fields (`resource`,
+`sources[].resource`, `computation`) accept absolute URLs, bundle-relative paths, or relative paths.
+
+## 5. Conformance — what binds a consumer
+
+A bundle is conformant if every non-reserved `.md` file has parseable YAML frontmatter containing a
+non-empty `type`, and reserved files follow their structure **[SPEC]**.
+
+The consumer obligations are the load-bearing part for AK, because they are all *tolerance* rules:
+
+- **MUST** treat a bare `verified` mapping as a one-element list.
+- **MUST NOT** reject a concept for missing optional fields or an unknown `type`.
+- **MUST NOT** reject a bundle for a missing `index.md`, a broken link, or unknown frontmatter keys.
+- **MUST** surface failed attestations rather than silently dropping them.
+- **SHOULD** derive trust tiers and staleness only from the specified fields.
+
+Read together: **a strict OKF reader is a non-conformant OKF reader.** Anything unrecognised is
+carried through, not refused. This is why the design's OKF backend degrades per-document instead of
+failing a load.
+
+## 6. Versioning
+
+- `<major>.<minor>`; minor bumps are backward-compatible additions.
+- A bundle may declare its target version as `okf_version: "0.2"` in the **bundle-root `index.md`**
+  frontmatter — the only frontmatter permitted in an index file.
+- v0.1 → v0.2 breaking changes a reader must absorb:
+  - `timestamp` was replaced by `generated: {by, at}`.
+  - A body `# Citations` list was replaced by the `sources` frontmatter family.
+
+## 7. Attested Computation
+
+A concept type (`type: Attested Computation`) describing a runnable, verifiable computation: a
+`runtime`, typed `parameters`, the computation itself (inline under `# Computation` or referenced by
+the `computation` path field), an `executor` that produces a receipt, and an `attester` that
+deterministically checks the receipt. The informative consumer workflow is discover → load →
+parameterize → execute → attest → gate (refuse failed attestations, warn on staleness).
+
+**Takeaway for AK:** executing these is a *sandbox* concern, not a knowledge-base concern — the
+executor runs arbitrary code. The design therefore reads such concepts like any other concept and
+declares execution a non-goal, rather than growing an execution path inside the KB layer.
+
+## 8. Reference implementations (prior art)
+
+- **Enrichment agent (producer):** walks a BigQuery dataset, drafts one concept per table/view, then
+  runs a second LLM pass to add citations, schemas, and join paths. Confirms the intended pattern is
+  *agents write OKF*, not just read it — the design keeps a conformant write path for this reason.
+- **Static HTML visualizer (consumer):** renders any bundle as an interactive graph from a single
+  self-contained file, with no backend.
+- Sample bundles published for GA4 e-commerce, Stack Overflow, and Bitcoin public datasets — usable
+  as fixtures for the conformance tests.
+
+## 9. Why this shapes the AK design
+
+| OKF property | Consequence for AK |
+|---|---|
+| Format, not storage — a bundle is just a directory | Representation must be separable from the byte store, so one OKF reader serves local FS and S3 |
+| Path is identity | Retrieval needs a *fetch-by-id* and a *browse* operation, which today's single `read(query)` hole cannot express |
+| Only `type` is required; producers invent types | The schema an agent is shown must be **derived** from the bundle, not hand-registered per deployment |
+| Consumers must tolerate everything | Degrade per document; never fail a bundle load on a bad file |
+| Trust/lifecycle frontmatter is advisory | Surface tier/staleness to the agent as signals; never filter on them silently |
+| Attested Computation executes code | Out of scope for the KB layer; belongs to the sandbox capability |

--- a/docs/specs/553-okf-knowledge-bases/research/okf-format-survey.md
+++ b/docs/specs/553-okf-knowledge-bases/research/okf-format-survey.md
@@ -5,8 +5,20 @@ consumer, and which of its properties drive the AK design decisions.
 
 **Verification status.** The v0.2 specification and the announcement blog were read on 2026-08-31 via
 web fetch, and the summaries below are that reading, not a verbatim transcription. Every normative
-statement marked **[SPEC]** must be re-checked against the specification text verbatim before it is
-implemented — the design's conformance requirements are only as good as this re-check.
+statement marked **[SPEC]** was **re-checked verbatim against `okf/SPEC.md` on 2026-09-01**, closing
+the verification gate the design records as decision 8. Outcome:
+
+- Verified as stated: reserved filenames (§2), `type` as the only required key (§3), the actor
+  convention and `human:` detection (§3), the trust-tier derivation (§3), the two link forms (§4), the
+  conformance definition (§5), the `okf_version` location (§6), and the two v0.1 → v0.2 breaking
+  changes (§6).
+- **One correction applied** (§5): surfacing a failing attestation is a **SHOULD**, not a MUST. The
+  earlier wording overstated it.
+- **Two clarifications applied**: reserved filenames are reserved *at any level* of the tree, and an
+  `index.md` may carry frontmatter **only** for `okf_version` at the bundle root (§2, §6); and the
+  v0.1 fallbacks are **MAY** (`timestamp`) / **SHOULD read `sources`, MAY parse legacy `# Citations`**
+  (§6), which is what makes the design's v0.2-only decision a conformant choice rather than a
+  deviation.
 
 Sources:
 - Announcement: https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing
@@ -39,7 +51,9 @@ sales/
 
 - **The file path is the concept's identity.** `/tables/orders.md` *is* the id. There is no separate
   id field, and nothing outside the path is authoritative.
-- `index.md` and `log.md` are **reserved filenames [SPEC]** — they are not concept documents.
+- `index.md` and `log.md` are **reserved filenames at any level of the tree [SPEC]** — they MUST NOT be
+  used for concept documents. An `index.md` carries no frontmatter at all, except the optional
+  `okf_version` at the bundle root (§6).
 - Distribution is by ordinary means: a git repo, a tarball, a mounted directory, an object-store
   prefix. Nothing in the format assumes a database.
 
@@ -108,7 +122,8 @@ The consumer obligations are the load-bearing part for AK, because they are all 
 - **MUST** treat a bare `verified` mapping as a one-element list.
 - **MUST NOT** reject a concept for missing optional fields or an unknown `type`.
 - **MUST NOT** reject a bundle for a missing `index.md`, a broken link, or unknown frontmatter keys.
-- **MUST** surface failed attestations rather than silently dropping them.
+- **MUST** tolerate broken links.
+- **SHOULD** surface, not silently drop, a failing attestation.
 - **SHOULD** derive trust tiers and staleness only from the specified fields.
 
 Read together: **a strict OKF reader is a non-conformant OKF reader.** Anything unrecognised is
@@ -120,9 +135,12 @@ failing a load.
 - `<major>.<minor>`; minor bumps are backward-compatible additions.
 - A bundle may declare its target version as `okf_version: "0.2"` in the **bundle-root `index.md`**
   frontmatter — the only frontmatter permitted in an index file.
-- v0.1 → v0.2 breaking changes a reader must absorb:
-  - `timestamp` was replaced by `generated: {by, at}`.
-  - A body `# Citations` list was replaced by the `sources` frontmatter family.
+- v0.1 → v0.2 breaking changes, and what a reader is *obliged* to do about them **[SPEC]**:
+  - `timestamp` is superseded by `generated.at`; a consumer **MAY** fall back to a legacy `timestamp`
+    when `generated` is absent.
+  - A body `# Citations` list is superseded by `sources`; a consumer **SHOULD** read `sources` and
+    **MAY** still parse a legacy `# Citations` body list for v0.1 documents.
+  - Both fallbacks are optional, so declining them (design decision 5, v0.2 only) is conformant.
 
 ## 7. Attested Computation
 

--- a/docs/specs/553-okf-knowledge-bases/research/okf-format-survey.md
+++ b/docs/specs/553-okf-knowledge-bases/research/okf-format-survey.md
@@ -47,7 +47,7 @@ sales/
 
 YAML frontmatter + markdown body.
 
-```yaml
+```markdown
 ---
 type: BigQuery Table                       # the ONLY required field [SPEC]
 title: Orders

--- a/docs/specs/553-okf-knowledge-bases/spec.md
+++ b/docs/specs/553-okf-knowledge-bases/spec.md
@@ -1,0 +1,1018 @@
+# #553: Open Knowledge Format support and the knowledge-base architecture refactor — Implementation Spec
+
+Details how the approved [`design.md`](design.md) is built. The knowledge-base tier is split along the
+three axes the design fixes — representation (`knowledgebase/okf/`), capability
+(`KnowledgeCapabilities` + the five-operation set on `KnowledgeBase`), and storage
+(`knowledgebase/store/`) — and Open Knowledge Format lands as `OKFManager`, a `DocumentKnowledgeBase`
+composing an OKF parser with a `DocumentStore`. `design.md` is the requirements source; every
+requirement there is traced into a section below. Sections that resolve something the design
+deliberately left to this stage, or that add a component the design does not name, are marked
+**[spec-level decision]** and collected in [Deviations and additions](#deviations-and-additions) for
+design re-review.
+
+Nothing in `ak-py/src` outside `agentkernel/knowledgebase/` imports the package (verified by grep over
+`ak-py/src` and `e2e`), so the blast radius is the package itself, the four examples under
+`examples/cli/knowledgebase/openai/`, three docs pages, and two dev skills.
+
+## Verification gate — decision 8, closed
+
+`design.md` decision 8 makes re-checking every `[SPEC]`-marked claim in
+[`research/okf-format-survey.md`](research/okf-format-survey.md) against the OKF **v0.2**
+specification text a precondition for this document. That re-check was performed against
+`okf/SPEC.md` in `GoogleCloudPlatform/knowledge-catalog` on 2026-09-01 and the survey's verification
+block now records it. Three outcomes bear on the conformance behavior fixed below:
+
+1. **Corrected**: surfacing a failing attestation is a **SHOULD**, not a MUST. The design never relied
+   on the stronger reading (it reads Attested Computation concepts like any other concept), so no
+   requirement changes — but `OKFManager` must not *drop* a failed attestation either, which it does
+   not: `verified` and the computation family are carried through as data.
+2. **Tightened**: reserved filenames are reserved **at any level** of the tree, and an `index.md` may
+   carry frontmatter **only** for `okf_version` **at the bundle root**. This is load-bearing for
+   `browse()` and for the walk — see [`index.md` handling](#indexmd-and-logmd-handling).
+3. **Clarified**: the v0.1 → v0.2 fallbacks are **MAY** (`timestamp`) and **SHOULD read `sources` /
+   MAY parse legacy `# Citations`**. Declining both — design decision 5, v0.2 only — is therefore a
+   conformant choice, not a deviation. The spec asserts this by test rather than leaving it as prose.
+
+## Design
+
+### Package layout
+
+```
+ak-py/src/agentkernel/knowledgebase/
+├── __init__.py           # REWRITTEN: lazy PEP 562 exports
+├── model.py              # NEW: KnowledgeCapabilities, KnowledgeMetadata, KnowledgeRecord
+├── errors.py             # NEW: KnowledgeError, KnowledgeCapabilityError, KnowledgePathError
+├── base.py               # CHANGED: capability-aware ABC, concrete read(), schema derivation
+├── document.py           # NEW: DocumentKnowledgeBase
+├── knowledgebuilder.py   # CHANGED: capability-gated tools, generic write metadata
+├── testing.py            # NEW: KnowledgeBaseContract, DocumentStoreContract, FakeKnowledgeBase
+├── chroma.py             # CHANGED: read -> search, declares capabilities
+├── neo4j.py              # CHANGED: read -> query, generic write metadata, declares capabilities
+├── starburst.py          # CHANGED: schema -> db_schema, read -> query, declares capabilities
+├── store/
+│   ├── __init__.py       # NEW: lazy exports (keeps boto3 optional)
+│   ├── base.py           # NEW: DocumentStore ABC, from_uri, path normalisation
+│   ├── local.py          # NEW: LocalDocumentStore (stdlib only)
+│   └── s3.py             # NEW: S3DocumentStore (existing `aws` extra)
+└── okf/
+    ├── __init__.py       # NEW: lazy exports
+    ├── model.py          # NEW: OKFConcept, OKFBundle, OKFDiagnostic, TrustTier
+    ├── parser.py         # NEW: bytes/str -> OKFConcept; links, trust, staleness
+    └── manager.py        # NEW: OKFManager
+```
+
+Rules governing the package, each stated so a reviewer can check it mechanically:
+
+1. **`okf/` never touches a `DocumentStore` or the network.** `parser.py` takes `bytes`/`str` and a
+   path string, and returns objects. Asserted by a test that imports `agentkernel.knowledgebase.okf`
+   and fails if `agentkernel.knowledgebase.store` appears in `sys.modules` on its account.
+2. **`store/` never knows markdown, YAML, or OKF.** No import of `yaml` or of `okf/` anywhere under
+   `store/`.
+3. **Stores take explicit constructor parameters and never read `AKConfig`** — the shared-driver and
+   transport rule. `from_uri` is a string parser, not a config reader.
+4. **`testing.py` imports `pytest`** and is therefore excluded from the package's lazy export map, the
+   `sandbox/testing.py` precedent.
+
+### `knowledgebase/model.py` — capability declaration and record typing
+
+```python
+class KnowledgeCapabilities(BaseModel):
+    """What a backend actually supports; undeclared operations raise KnowledgeCapabilityError."""
+
+    kinds: list[str] = Field(default_factory=list)        # open taxonomy: vector|structured|graph|document|…
+    search: bool = False                                   # relevance retrieval
+    search_mode: Literal["semantic", "lexical"] | None = None
+    query: bool = False                                    # query-language retrieval
+    query_language: str | None = None                      # e.g. "cypher", "sql"
+    fetch: bool = False                                    # retrieval by identity
+    browse: bool = False                                   # namespace enumeration
+    writable: bool = False
+    derives_schema: bool = False                           # schema() self-describes without add_schema()
+```
+
+- **The model carries no cross-field validator** — both invariants are enforced in
+  `KnowledgeBase.__init__`, because the design requires each `ValueError` to *name the backend* and the
+  capabilities object does not know it. An application can therefore build a `KnowledgeCapabilities`
+  for inspection without owning a backend. **[spec-level decision]**
+- **`search_mode` is deliberately *not* bidirectional with `search`**, unlike `query_language`/`query`.
+  The design declares exactly two invariants and nothing routes on `search_mode` — it is advisory
+  metadata reaching the agent through `schema()`. `search=True, search_mode=None` is legal and means
+  "relevance retrieval, kind unstated". Recorded here so the asymmetry reads as considered.
+- Two `TypedDict`s (`total=False`), documentation-only, never validated at runtime:
+
+```python
+class KnowledgeMetadata(TypedDict, total=False):
+    id: str          # backend-native identity; REQUIRED in metadata when capabilities.fetch is True
+    source: str
+    title: str
+    kind: str
+    trust: str
+    stale: bool
+    links: list[str]
+
+class KnowledgeRecord(TypedDict, total=False):
+    text: str
+    metadata: KnowledgeMetadata
+```
+
+`Record = Mapping[str, Any]` stays the annotation on every signature; neither `TypedDict` appears in
+one. The `id` rule is enforced by `KnowledgeBaseContract`, not by runtime validation.
+
+### `knowledgebase/errors.py`
+
+```python
+class KnowledgeError(Exception): ...
+
+class KnowledgeCapabilityError(KnowledgeError):
+    """An operation the backend does not declare in its KnowledgeCapabilities."""
+    def __init__(self, *args: str) -> None: ...   # (subject, operation) or (operation,)
+
+class KnowledgePathError(KnowledgeError):
+    """A path escaped the store's namespace, or is otherwise unusable as an identity."""
+```
+
+- `KnowledgeCapabilityError` mirrors `SandboxCapabilityError` (`sandbox/errors.py:20-39`) exactly,
+  including the message `"{subject} does not support capability: {operation}"` and the
+  `subject`/`capability` attributes. It does **not** subclass `NotImplementedError` (design item 2).
+- `KnowledgePathError` is an **addition** the design does not name: the design says the store refuses
+  an escaping path and `DocumentKnowledgeBase` maps the refusal to an agent-facing error result. That
+  mapping needs a type to catch, and catching `ValueError` would also swallow unrelated failures.
+  **[spec-level decision]** — see [Deviations and additions](#deviations-and-additions) A.
+
+### `knowledgebase/base.py` — the reshaped ABC
+
+```python
+class KnowledgeBase(ABC):
+    capabilities: KnowledgeCapabilities          # bare annotation, no class-level default
+
+    def __init__(self, capabilities: KnowledgeCapabilities, name: str | None = None) -> None:
+        self._dynamic_schema: dict[str, Any] = {}
+        self.capabilities = capabilities
+        validate_capabilities(capabilities, name or type(self).__name__)
+
+    # unchanged abstract surface
+    @property
+    @abstractmethod
+    def backend_name(self) -> str: ...
+    @abstractmethod
+    def connect(self, **kwargs) -> None: ...
+    @abstractmethod
+    def get_description(self) -> str: ...
+
+    # the five operations — all concrete, all optional
+    def search(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
+        raise KnowledgeCapabilityError(self.backend_name, "search")
+    def query(self, statement: str, limit: int = 3, **kwargs) -> List[Record]:
+        raise KnowledgeCapabilityError(self.backend_name, "query")
+    def fetch(self, ids: List[str], **kwargs) -> List[Record]:
+        raise KnowledgeCapabilityError(self.backend_name, "fetch")
+    def browse(self, path: str = "", limit: int = 50, **kwargs) -> List[Record]:
+        raise KnowledgeCapabilityError(self.backend_name, "browse")
+    def write(self, records: Iterable[Record], **kwargs) -> None:
+        raise KnowledgeCapabilityError(self.backend_name, "write")
+
+    # the routing rule — the design's single statement of it
+    def read(self, query: str, limit: int = 3, **kwargs) -> List[Record]:
+        if self.capabilities.query:
+            return self.query(query, limit=limit, **kwargs)
+        return self.search(query, limit=limit, **kwargs)
+```
+
+- `read` and `write` **stop being abstract**. A subclass that implements them keeps working unchanged;
+  a new subclass may omit both. `connect`, `backend_name`, and `get_description` stay abstract, so the
+  required surface shrinks from five members to three.
+- The default operations raise with `self.backend_name`, which is safe: by the time an operation is
+  called the subclass is fully constructed. Only the **construction-time** validation is forbidden from
+  reading the property.
+- `validate_capabilities(capabilities, subject) -> None` is a module-level function, not a private
+  method, so `KnowledgeBaseContract` can exercise it directly without constructing a backend:
+
+```python
+def validate_capabilities(capabilities: KnowledgeCapabilities, subject: str) -> None:
+    if not (capabilities.search or capabilities.query or capabilities.fetch
+            or capabilities.browse or capabilities.writable):
+        raise ValueError(f"Knowledge backend '{subject}' declares no capability: at least one of "
+                         "search, query, fetch, browse, writable must be True.")
+    if capabilities.query and not (capabilities.query_language or "").strip():
+        raise ValueError(f"Knowledge backend '{subject}' declares query=True without a query_language.")
+    if not capabilities.query and (capabilities.query_language or "").strip():
+        raise ValueError(f"Knowledge backend '{subject}' declares query_language "
+                         f"{capabilities.query_language!r} without query=True.")
+```
+
+Both invariants raise `ValueError` naming the backend, and the reachability check runs first so a
+capability-free backend reports the more fundamental problem.
+
+#### Schema derivation
+
+```python
+def _derived_schema(self) -> Mapping[str, Any]:
+    return {}
+
+def schema(self) -> Mapping[str, Any]:
+    derived = dict(self._derived_schema())
+    if not self._dynamic_schema and not derived:
+        raise ValueError(f"Schema for '{self.backend_name}' has not been set! "
+                         "Call .add_schema() before passing to the Agent.")
+    final: dict[str, Any] = {"backend": self.backend_name}
+    final.update(derived)
+    final.update(self._dynamic_schema)
+    final["capabilities"] = self.capabilities.model_dump()
+    return final
+```
+
+- The `ValueError` message is **byte-identical** to today's (`base.py:57-58`), so any deployment
+  matching on it is unaffected.
+- Precedence: `backend` first and therefore overridable by `add_schema()` — today's behavior,
+  preserved. `capabilities` is written **last and is not overridable**, because it is the
+  machine-readable declaration the tools route on and a deployment must not be able to contradict it
+  through `add_schema()`. The design says only "also add `capabilities`" and leaves precedence open.
+  **[spec-level decision]**
+- Neither `backend` nor `capabilities` counts as content for the emptiness guard, which is why the
+  guard is evaluated before they are added.
+- `capabilities.derives_schema` is a declaration, not the gate: `KnowledgeBaseContract` fails a backend
+  declaring it while `_derived_schema()` returns `{}`.
+
+#### `format_results`
+
+```python
+def format_results(self, rows: List[Record]) -> str:
+    if not rows:
+        return "No relevant knowledge found."
+    lines = []
+    for row in rows:
+        metadata = row.get("metadata", {}) or {}
+        text, source = row.get("text", ""), metadata.get("source", "N/A")
+        record_id = metadata.get("id")
+        if self.capabilities.fetch and isinstance(record_id, str) and record_id:
+            lines.append(f"- [{record_id}] {text} (source: {source})")
+        else:
+            lines.append(f"- {text} (source: {source})")
+    return "\n".join(lines)
+```
+
+The unprefixed branch is byte-for-byte `base.py:103`. A missing, empty, or non-string `id` on a
+`fetch`-capable backend degrades to it rather than rendering `[None]`.
+
+### `knowledgebase/store/` — the storage axis
+
+```python
+class DocumentStore(ABC):
+    @property
+    @abstractmethod
+    def writable(self) -> bool: ...
+    @abstractmethod
+    def read_bytes(self, path: str) -> bytes: ...          # FileNotFoundError when absent
+    @abstractmethod
+    def exists(self, path: str) -> bool: ...
+    @abstractmethod
+    def list(self, prefix: str = "") -> list[str]: ...     # lexicographic, bundle-relative
+    @abstractmethod
+    def write_bytes(self, path: str, data: bytes) -> None: ...
+    def read_prefix_bytes(self, path: str, max_bytes: int) -> bytes:
+        return self.read_bytes(path)[:max_bytes]           # overridable; S3 uses a ranged GET
+    def close(self) -> None: ...
+    @staticmethod
+    def from_uri(uri: str, **kwargs) -> "DocumentStore": ...
+```
+
+- **`read_prefix_bytes` is an addition** to the design's five-method contract, with a default that
+  makes it invisible to a bring-your-own store. It exists so the eager frontmatter pass is affordable
+  over S3 — see [Manifest: what is retained](#manifest-what-is-retained-and-what-it-costs).
+  **[spec-level decision]** — [Deviations and additions](#deviations-and-additions) C.
+- **Containment is the store's obligation** and is implemented once, in `store/base.py`:
+
+```python
+def normalise_relative(path: str) -> str:
+    """Bundle-relative, POSIX, containment-checked. Raises KnowledgePathError on an escape."""
+    candidate = (path or "").strip().replace("\\", "/")
+    if candidate.startswith("/"):
+        raise KnowledgePathError(f"absolute path is not addressable in a document store: {path!r}")
+    normalised = posixpath.normpath(candidate)
+    if normalised in (".", ""):
+        return ""
+    if normalised == ".." or normalised.startswith("../"):
+        raise KnowledgePathError(f"path escapes the store namespace: {path!r}")
+    return normalised
+```
+
+  Every entrypoint (`read_bytes`, `read_prefix_bytes`, `exists`, `write_bytes`, `list`'s prefix) calls
+  it first, and every path `list()` *emits* is produced by it — so containment covers paths no agent
+  supplied: the manifest walk and links read out of a concept.
+- `write_bytes` on a store declaring `writable=False` raises
+  `KnowledgeCapabilityError(type(self).__name__, "write_bytes")`, before any I/O.
+
+#### `LocalDocumentStore(root: str, writable: bool | None = None)`
+
+- Stdlib only; no extra.
+- `__init__` resolves `self._root = os.path.realpath(root)` and raises `ValueError` if it is not an
+  existing directory — matching `StarburstManager.connect`'s missing-config behavior
+  (`starburst.py:102`).
+- `writable=None` probes `os.access(self._root, os.W_OK)`; an explicit `True`/`False` wins. Probing is
+  right here and wrong for S3, where a permission cannot be read without attempting a write.
+  **[spec-level decision]**
+- **Traversal-time containment**, in addition to access-time: `list()` walks with `os.walk(root,
+  followlinks=False)`, and for each candidate file compares
+  `os.path.commonpath([self._root, os.path.realpath(full_path)]) == self._root`; a symlink resolving
+  outside `root` is **skipped** by the walk and **refused** (`KnowledgePathError`) on direct read.
+- `list()` collects every match and returns `sorted(matches)`. It does not rely on `os.walk`'s
+  per-directory ordering, which is not globally lexicographic (`a/z.md` vs `ab/b.md`), and global
+  lexicographic order is what makes `max_concepts` truncation identical across pods.
+- `read_bytes` on a missing file propagates the stdlib `FileNotFoundError`.
+
+#### `S3DocumentStore(bucket, prefix="", region=None, client=None, writable=True)`
+
+- Requires the existing `aws` extra (`boto3>=1.41.4`, `pyproject.toml:59`); **no new extra**. The
+  import is wrapped in `require_extra("aws", "s3:// document store")` (`core/util/factory.py:50`), so a
+  missing `boto3` is an `ImportError` naming the extra.
+- `client` injection is the test seam; otherwise `boto3.client("s3", region_name=region)`.
+- `list()` pages `list_objects_v2` with `Prefix=self._key(prefix)` and concatenates pages in order —
+  S3 already lists in UTF-8 binary order, and the result is `sorted()` anyway so the two orders cannot
+  diverge for keys that differ only in case-folding assumptions.
+- `read_bytes` maps `ClientError` with code `NoSuchKey` (and `404`) to `FileNotFoundError`, so the
+  layer above sees one exception type regardless of store. Every other `ClientError` propagates.
+- `read_prefix_bytes` issues `get_object(..., Range=f"bytes=0-{max_bytes - 1}")` and maps
+  `InvalidRange` on a shorter object to a full `read_bytes`.
+- `writable` is a **declared** constructor flag defaulting to `True`; the store never probes the bucket
+  policy. An application serving a read-only prefix passes `writable=False`, and `OKFManager` folds
+  that into `capabilities.writable` — the design's stated reason capabilities are per instance.
+
+#### `DocumentStore.from_uri`
+
+| Input | Resolves to |
+|---|---|
+| `s3://bucket/prefix` | `S3DocumentStore(bucket, prefix, **kwargs)` |
+| `file:///abs/path` | `LocalDocumentStore("/abs/path", **kwargs)` |
+| bare path (`./bundle`, `/srv/kb`) | `LocalDocumentStore(path, **kwargs)` |
+| `python:pkg.mod.ClassName` | `resolve_dotted(rest, base=DocumentStore, error=AKConfigError)(**kwargs)` |
+| any other `scheme://` | `AKConfigError` |
+
+"Any other scheme" is detected with `re.match(r"^[A-Za-z][A-Za-z0-9+.\-]*://", uri)` — a bare Windows-ish
+path or a relative path never trips it. The `python:` discriminator is mandatory because a dotted path
+*is* a valid bare path; without it, `mypkg.stores.GitStore` would silently become a
+`LocalDocumentStore` rooted at a non-existent directory.
+
+### `knowledgebase/okf/` — the representation axis
+
+#### `okf/model.py`
+
+```python
+class TrustTier(str, Enum):
+    UNVERIFIED = "unverified"
+    MACHINE_CONFIRMED = "machine-confirmed"
+    HUMAN_REVIEWED = "human-reviewed"
+
+class OKFDiagnostic(BaseModel):
+    path: str          # "" for bundle-level diagnostics
+    code: str          # see the table below
+    message: str
+
+class OKFConcept(BaseModel):
+    path: str                                   # identity; bundle-relative, POSIX
+    type: str                                   # the only required frontmatter key
+    title: str | None = None
+    description: str | None = None
+    resource: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    status: str | None = None                   # draft | stable | deprecated (open)
+    stale_after: str | None = None              # verbatim frontmatter value
+    generated: dict[str, Any] = Field(default_factory=dict)
+    verified: list[dict[str, Any]] = Field(default_factory=list)
+    sources: list[dict[str, Any]] = Field(default_factory=list)
+    computation: dict[str, Any] = Field(default_factory=dict)   # runtime/parameters/computation/executor/attester
+    extra: dict[str, Any] = Field(default_factory=dict)          # every unrecognised frontmatter key
+    trust: TrustTier = TrustTier.UNVERIFIED     # derived
+    stale: bool = False                          # derived
+    body: str | None = None                      # None when only a bounded prefix was scanned
+    body_tokens: set[str] = Field(default_factory=set)
+    links: list[str] = Field(default_factory=list)   # populated only when body is complete
+
+class OKFBundle(BaseModel):
+    concepts: dict[str, OKFConcept] = Field(default_factory=dict)
+    index_files: dict[str, str] = Field(default_factory=dict)   # directory ("" = root) -> index.md path
+    log_files: list[str] = Field(default_factory=list)
+    okf_version: str | None = None
+    diagnostics: list[OKFDiagnostic] = Field(default_factory=list)
+    truncated: bool = False
+```
+
+- `status` stays an open `str`, not an enum: the conformance rules forbid rejecting an unknown value,
+  and an enum would force either a rejection or a silent coercion.
+- `tags` accepts a scalar and normalises to a one-element list, the same tolerance the spec mandates
+  for `verified`. A non-string scalar is stringified, with a diagnostic.
+
+Diagnostic codes, exhaustively:
+
+| Code | Raised when |
+|---|---|
+| `unparseable_frontmatter` | no frontmatter block, or `yaml.safe_load` raises / returns a non-mapping |
+| `missing_type` | `type` absent, not a string, or empty after `strip()` |
+| `comma_in_path` | a concept path contains `,` (it could never round-trip through `fetch_kb`) |
+| `path_escape` | a link or listed path escapes the bundle namespace |
+| `version_mismatch` | bundle-root `okf_version` is present and is not `"0.2"` |
+| `index_frontmatter` | an `index.md` outside the bundle root carries a frontmatter block |
+| `unparseable_stale_after` | `stale_after` is not an ISO-8601 timestamp |
+| `coerced_scalar` | a bare `verified` mapping or a scalar `tags` value was normalised |
+| `truncated` | the walk stopped at `max_concepts` |
+| `unreadable` | the store raised while reading a candidate file |
+
+#### `okf/parser.py`
+
+```python
+FRONTMATTER_MAX_BYTES = 16 * 1024
+BODY_INDEX_MAX_BYTES = 8 * 1024
+
+def split_frontmatter(data: str) -> tuple[str | None, str]: ...
+def parse_concept(path: str, data: str, *, body_complete: bool) -> tuple[OKFConcept | None, list[OKFDiagnostic]]: ...
+def extract_links(concept_path: str, body: str) -> tuple[list[str], list[OKFDiagnostic]]: ...
+def derive_trust(verified: list[dict[str, Any]]) -> TrustTier: ...
+def is_stale(stale_after: str | None, now: datetime) -> tuple[bool, list[OKFDiagnostic]]: ...
+```
+
+- **Frontmatter delimiters**: the document must open with `---` on its own first line; the block ends at
+  the next line that is exactly `---`. No closing delimiter → `unparseable_frontmatter`, concept
+  skipped. `yaml.safe_load` only — never `yaml.load`. `pyyaml>=6.0.2` is a **core** dependency
+  (`pyproject.toml:19`), so a local-filesystem OKF backend needs no optional extra at all.
+- **Tolerance, per the conformance rules** (all asserted by test):
+  - unknown frontmatter keys → `extra`, untouched;
+  - unknown `type` values → kept verbatim;
+  - missing optional fields → defaults, no diagnostic;
+  - a bare `verified` mapping → one-element list (`coerced_scalar`);
+  - a broken link → kept in `links`, never resolved against the store at parse time;
+  - a v0.1 `timestamp` key → `extra["timestamp"]`, **never** mapped onto `generated`; a body
+    `# Citations` list → ordinary body text, **never** mapped onto `sources`. Conformant because both
+    fallbacks are MAY (verification gate outcome 3).
+- **Trust** derives only from `verified`: empty → `UNVERIFIED`; any entry whose `by` starts with
+  `human:` → `HUMAN_REVIEWED`; otherwise `MACHINE_CONFIRMED`. Nothing else feeds it.
+- **Staleness** derives only from `stale_after`, parsed with `datetime.fromisoformat` (accepting a
+  trailing `Z` by substitution), compared against an injected `now` so tests are deterministic. A naive
+  timestamp is read as UTC. Unparseable → `stale=False` plus `unparseable_stale_after`.
+- **Nothing is ever filtered on trust or staleness.** They ride on every returned record as
+  `metadata["trust"]` / `metadata["stale"]`. Asserted by a test that registers a bundle whose every
+  concept is stale and unverified and checks `search`/`browse`/`fetch` still return them all.
+- **Links**: `re.finditer(r"\[[^\]]*\]\(([^)\s]+)\)", body)`. A target is kept when it has no URL
+  scheme and ends in `.md`; `/x/y.md` resolves bundle-absolute to `x/y.md`, `./y.md` and `../y.md`
+  resolve against `posixpath.dirname(concept_path)`. An escape is dropped with `path_escape`.
+  Absolute-URL targets are ignored here and never dereferenced anywhere in the layer.
+- **No network fetch of reference fields.** `resource`, `sources[].resource`, and `computation` are
+  carried as data. Asserted by a test that fails if the parser or manager touches `urllib`/`httpx`.
+
+#### `index.md` and `log.md` handling
+
+Driven by verification-gate outcome 2:
+
+- Both names are reserved **at every directory level** and are never parsed as concepts.
+- `index.md` at the **bundle root** may carry a frontmatter block, and `okf_version` is the only key
+  read from it; other keys there are ignored with no diagnostic (the spec permits only this one key, so
+  anything else is unrecognised content, which tolerance says to carry, not reject).
+- An `index.md` **outside** the root carrying a frontmatter block gets an `index_frontmatter`
+  diagnostic and its body is still used as the curated listing — carried, not rejected.
+- `log.md` is recorded in `log_files` and otherwise untouched.
+
+### `knowledgebase/document.py` — `DocumentKnowledgeBase`
+
+The only new intermediate base class. It holds the store, folds `store.writable` into the capabilities
+it was handed, and owns the two error mappings so `OKFManager` (and any second document-shaped
+backend) does not repeat them:
+
+```python
+class DocumentKnowledgeBase(KnowledgeBase, ABC):
+    def __init__(self, store: DocumentStore, capabilities: KnowledgeCapabilities, name: str | None = None) -> None:
+        self._store = store
+        capabilities = capabilities.model_copy(update={"writable": capabilities.writable and store.writable})
+        super().__init__(capabilities=capabilities, name=name)
+
+    @property
+    def store(self) -> DocumentStore: ...
+
+    def _read_document(self, path: str) -> bytes | None:
+        """None on a missing document; KnowledgePathError propagates to the operation boundary."""
+        try:
+            return self._store.read_bytes(path)
+        except FileNotFoundError:
+            log.warning("[%s] document not found: %s", self.backend_name, path)
+            return None
+```
+
+- Folding uses `and`, so a store that cannot write always wins over a declared `writable=True`; the
+  reverse (a writable store, a backend that chooses not to write) also holds.
+- `KnowledgePathError` is **not** swallowed here: each of `fetch`/`browse`/`write` catches it at its own
+  boundary and returns/raises per the design ("`DocumentKnowledgeBase` turns the refusal into an error
+  result for the agent"), which in practice means the operation drops that path with a logged warning
+  and continues with the rest. Containment is still enforced in the store, which is the only place an
+  escape is *detected*.
+- `close()` delegates to `store.close()`.
+
+### `knowledgebase/okf/manager.py` — `OKFManager`
+
+```python
+OKFManager(
+    store: DocumentStore,
+    name: str = "",
+    description: str | None = None,
+    refresh_seconds: float | None = 300.0,
+    max_concepts: int = 10_000,
+    producer: str | None = None,
+    write_prefix: str = "generated",
+)
+```
+
+Capabilities built in `__init__` from what it was given:
+`kinds=["document"], search=True, search_mode="lexical", query=False, query_language=None, fetch=True,
+browse=True, writable=store.writable, derives_schema=True`. `query=False` is what makes `read()` route
+to `search()` under the base's rule, and is why `search_kb` is not emitted on OKF's account.
+
+#### Manifest: what is retained, and what it costs
+
+`connect()` walks the store once and holds one `OKFBundle` in process. Per concept the manifest retains
+the parsed frontmatter, the derived trust/staleness, and a **bounded body token set** — not the body
+text:
+
+- The walk reads `store.read_prefix_bytes(path, FRONTMATTER_MAX_BYTES + BODY_INDEX_MAX_BYTES)`
+  (24 KiB by default). If no closing `---` is found within it, the walk falls back to a full
+  `read_bytes` for that one file, because a concept whose frontmatter exceeds 16 KiB is unusual but
+  must not be skipped.
+- `body_tokens` is built from the body bytes inside that window; `body` and `links` are left `None`/
+  empty, and `body_complete=False` is recorded.
+- **`fetch` is the only operation that reads a full body.** It re-reads the document, re-parses with
+  `body_complete=True`, and therefore is the only operation whose records carry `metadata["links"]` —
+  which is exactly how the design describes graph traversal ("attached as `metadata["links"]`, so an
+  agent can traverse the graph with `fetch`").
+
+This refines the design's "frontmatter is parsed eagerly … bodies are read lazily": a lexical ranker
+cannot rank over bodies it never reads, so what is retained is a bounded token index of the body head
+rather than the body. **[spec-level decision]** — [Deviations and additions](#deviations-and-additions) F.
+
+**Per-operation cost, stated:** every `search`/`fetch`/`browse`/`schema`/`get_description` call runs
+`_ensure_manifest()`, whose steady-state cost is one `time.monotonic()` comparison. The call that
+crosses the `refresh_seconds` boundary pays the whole walk: for a local bundle, one `os.walk` plus one
+bounded read per concept; for S3, one `list_objects_v2` pagination plus **one ranged GET per concept**.
+At the 10,000-concept design target and the 300 s default that is 10,000 ranged GETs every five
+minutes *per pod*. The backend's docstring and `docs/docs/advanced/knowledge-bases.md` must both say
+so, and recommend a larger `refresh_seconds` — or `None` for an immutable bundle — for large S3
+bundles.
+
+**Envelope:** the ~50 MB target covers frontmatter plus token sets for 10,000 concepts (~5 KB each).
+Bodies are excluded because they are never retained between calls.
+
+`max_concepts` truncation: the walk consumes `store.list()` in its contractual lexicographic order and
+stops after `max_concepts` **accepted** concepts (skipped files do not consume budget), sets
+`truncated=True`, and appends a `truncated` diagnostic naming the count and the limit. The bundle still
+loads and serves.
+
+#### Refresh and concurrency
+
+```python
+def _ensure_manifest(self) -> OKFBundle:
+    manifest = self._manifest
+    if manifest is None:                                   # initial load: blocking, nothing to serve
+        with self._refresh_lock:
+            if self._manifest is None:
+                self._manifest = self._walk()
+                self._loaded_at = time.monotonic()
+            return self._manifest
+    if self._refresh_seconds is None or (time.monotonic() - self._loaded_at) < self._refresh_seconds:
+        return manifest
+    if self._refresh_lock.acquire(blocking=False):          # refresh: never blocks a caller
+        try:
+            self._manifest = self._walk()
+        except Exception as exc:
+            log.warning("[%s] manifest refresh failed, serving the previous manifest: %s", self.backend_name, exc)
+        finally:
+            self._loaded_at = time.monotonic()
+            self._refresh_lock.release()
+    return self._manifest
+```
+
+The concurrency contract, in full:
+
+- **`threading.Lock`, not an asyncio primitive.** The whole KB tier is synchronous, and the tools
+  `KnowledgeBuilder.build()` returns are plain sync functions — a framework may run them on a thread
+  pool, and the ECS/pipeline agent-runner topology runs several consumer threads per process.
+- **Two concurrent callers crossing the boundary produce one walk.** The loser does not block and is
+  served the current manifest, one interval stale.
+- **The manifest is swapped as a whole** (a single attribute assignment), so no caller ever observes a
+  half-built manifest.
+- **A failed refresh keeps the previous manifest and resets the clock**, so an S3 outage costs one
+  attempt per interval rather than one per tool call. The **initial** load propagates instead —
+  `connect()` failing loudly is the right behavior for a misconfigured store.
+- **`reload()`** forces an immediate walk under the blocking lock; `refresh_seconds=None` disables
+  automatic refresh entirely.
+- **A write racing a refresh**: `write()` inserts into the live manifest's `concepts` dict (atomic per
+  key under CPython), while a refresh replaces the whole object. A write completing between a refresh's
+  `_walk()` and its assignment is therefore dropped *from the manifest* — never from the store, where
+  the bytes are already durable — and reappears on the next walk. Documented rather than locked
+  against, because bundle-level write concurrency control is an explicit non-goal.
+
+#### Operations
+
+**`search(query, limit=3)`** — lexical, deterministic:
+
+- Tokenisation: lowercase, split on `[^a-z0-9]+`, drop tokens shorter than two characters, applied
+  identically to the query and to every indexed field.
+- Field weights: `title` 4, `tags` 3, `type` 2, `description` 2, `body_tokens` 1. A concept's score is
+  the sum, over distinct query tokens, of the weight of each field containing that token. Presence, not
+  frequency — term frequency over a bounded body window would reward long preambles.
+- Only concepts scoring `> 0` are returned. Ordering is `(-score, path)`, so ties break
+  lexicographically and the result is reproducible across processes. Asserted by test.
+- Records: `text` = `description` or `title` or `path`; `metadata` = `{id, source, title, kind: type,
+  trust, stale}`. No `links` (the body is not complete).
+
+**`fetch(ids)`** — ids in, records out, **in the order requested**. An unknown or unreadable id is
+omitted with a logged warning (never an exception, never a placeholder record). Each record carries the
+full body as `text` and the complete `links` list. A duplicate id yields one record.
+
+**`browse(path="", limit=50)`**:
+
+- If the browsed directory has an `index.md`, return **one** record whose `text` is that file's body,
+  `metadata["kind"] = "index"`, `metadata["id"]` = the index path. `limit` does not truncate a curated
+  listing. This holds at **any** level, not just the root — `index.md` is reserved everywhere.
+- Otherwise derive the listing from the manifest: the immediate children of that directory, both
+  concepts and subdirectories, in lexicographic order, truncated to `limit`. A subdirectory record has
+  `metadata["kind"] = "directory"` and an `id` ending in `/`; a concept record is shaped like a
+  `search` record.
+- An unknown directory returns `[]` with a logged warning.
+
+**`write(records)`**:
+
+- Refuses when `capabilities.writable` is `False`, with `KnowledgeCapabilityError`.
+- Path resolution per record:
+  1. `metadata["id"]` when present — normalised through `normalise_relative`, and **rejected with
+     `KnowledgePathError` if it contains a `,`** so every id the backend hands out round-trips through
+     `fetch_kb`;
+  2. otherwise **synthesised**: `f"{write_prefix}/{slug}-{uuid4().hex[:8]}.md"`, where `slug` is a
+     comma-free `[a-z0-9-]` slug of `metadata["title"]`, else of `metadata["type"]`, else `"concept"`.
+     Synthesis is required because `write_kb`'s signature carries no id and the design's non-changes
+     freeze it. **[spec-level decision]** — [Deviations and additions](#deviations-and-additions) B.
+- `type` is `metadata["type"]` when non-empty, else `"Note"` — a non-empty `type` is the whole
+  conformance bar for a concept document, so it can never be omitted.
+- Emitted document: `---\n` + `yaml.safe_dump(frontmatter, sort_keys=False, default_flow_style=False,
+  allow_unicode=True)` + `---\n\n` + `record["text"]`. Frontmatter key order is fixed as `type`,
+  `title`, `description`, `tags`, `status`, `generated`, `sources`, then any caller extras, so two
+  writes of the same content are byte-identical.
+- `generated` is always stamped: `{"by": <producer>, "at": <ISO-8601 UTC, seconds precision>}`.
+- **Write-through**: after `store.write_bytes` returns, the rendered document is parsed with
+  `body_complete=True` and inserted into the live manifest, replacing any entry at that path. The
+  concept is therefore visible to `fetch`, `browse`, and `search` in the very next call, independent of
+  `refresh_seconds`.
+
+**Producer string.** `producer` defaults to `f"agentkernel/{version}"`, where `version` comes from
+`importlib.metadata.version("agentkernel")` — the idiom already used at
+`deployment/aws/__init__.py:5-8` — falling back to `"agentkernel/unknown"` on
+`PackageNotFoundError` (a fallback is required: the package is importable from a source tree without
+distribution metadata). It is resolved **once in `__init__`**, not per write. An explicit `producer` is
+used verbatim after a non-empty check; the `<producer>/<version>` shape is a spec *convention*, and the
+same field legitimately carries `process:<id>` for automation, so the value is not pattern-validated.
+
+**`_derived_schema()`** returns, read from the loaded manifest and never hand-transcribed:
+
+```python
+{"okf_version": bundle.okf_version, "concept_count": len(bundle.concepts),
+ "types": sorted({c.type for c in bundle.concepts.values()}),
+ "top_level_directories": sorted(...), "reserved_files": {"index": [...], "log": [...]},
+ "diagnostics": len(bundle.diagnostics), "truncated": bundle.truncated}
+```
+
+**`get_description()`** returns `f"{backend_name}: {description}"` plus, when diagnostics exist,
+`f" ({n} bundle diagnostic(s); first: {code} at {path})"` — surfaced, not swallowed. Diagnostics are
+also logged at `warning` on each walk.
+
+**`format_results`** overrides the base:
+`- [<id>] <title> — <type> · trust=<tier>[ · STALE]`, falling back to the path when `title` is absent.
+Prompt-visible by construction; asserted by test.
+
+### `knowledgebase/knowledgebuilder.py` — the agent surface
+
+The four existing tools keep their names and signatures. Three are added, each gated on the
+**registered set**:
+
+| Tool | Emitted when |
+|---|---|
+| `search_kb(backend, query, limit=3)` | some backend declares **both** `search` and `query` |
+| `fetch_kb(backend, ids)` | some backend declares `fetch` |
+| `browse_kb(backend, path="", limit=50)` | some backend declares `browse` |
+
+- Appended in the order `search_kb`, `fetch_kb`, `browse_kb` after the existing four, so the tool list
+  is stable across runs for a given registered set. A vector-only application's list is unchanged
+  (`build()` returns the same four callables).
+- Routing at a backend that does not declare the capability returns an actionable **string**, never an
+  exception into the framework — matching `read_kb`'s existing behavior
+  (`knowledgebuilder.py:118-119,128-130`): `f"Backend '{name}' does not support {capability}. Backends
+  that do: {supported}."`
+- `search_kb`'s narrower gate: for a search-only backend `read_kb` already reaches `search()`, so a
+  second tool doing the same thing would only give the agent a redundant choice. Once emitted, it
+  routes at **any** backend declaring `search`.
+- `fetch_kb` splits `ids` on `,`, strips each segment, and drops empty segments. An all-empty argument
+  returns the "provide at least one id" string.
+- **Semantic-map resolution** (`knowledgebuilder.py:76-89`) is applied to `search_kb` queries,
+  `fetch_kb` ids (per segment, after splitting), and `browse_kb` paths, so a bundle root can be an
+  environment-swappable token.
+- `get_schemas` gains the per-backend `try/except` its sibling `get_all_kb_descriptions` already has
+  (`knowledgebuilder.py:185-187`), emitting `{"error": str(exc)}` for the failing backend instead of
+  failing the whole call.
+- `write_kb` stops setting `cypher_query`/`cypher_params`; it sets the generic `query`/`params` only.
+  The `if resolved_query:` guard and every existing validation string are unchanged.
+- **Defensive capability read**: `getattr(backend, "capabilities", None)` — a subclass that overrides
+  `__init__` without calling `super().__init__()` has no `capabilities`, and `build()` must warn naming
+  that backend and treat it as declaring nothing rather than raising `AttributeError` while building
+  the tool list.
+- **Exception scope is unchanged**: the tool bodies keep catching bare `Exception` and returning a
+  string. Narrowing them would change which failures reach the agent as text; that is not this change.
+
+### Consumer changes
+
+#### `ChromaManager` (`chroma.py`)
+
+- `__init__` calls `super().__init__(capabilities=KnowledgeCapabilities(kinds=["vector"], search=True,
+  search_mode="semantic", writable=True), name=name)`.
+- `read` → **`search`**, body and signature otherwise unchanged (`limit: int = 3` already matches the
+  base).
+- Unchanged: `connect`, `write`, `backend_name`, `get_description`, the `chromadb` extra.
+
+#### `Neo4jManager` (`neo4j.py`)
+
+- Capabilities: `kinds=["graph", "structured"], query=True, query_language="cypher", writable=True`.
+- `read` → **`query`**, first parameter renamed `query` → `statement` to match the base, and the default
+  `limit` moves from 10 to 3.
+- `write` reads `metadata["query"]` first and falls back to `metadata["cypher_query"]` (same for
+  `params`/`cypher_params`), and **skips a record carrying neither** with a logged warning instead of
+  calling `_run(None, {})`:
+
+```python
+statement = meta.get("query") or meta.get("cypher_query")
+params = meta.get("params") or meta.get("cypher_params") or {}
+if not statement:
+    log.warning("[neo4j.write] record carries no query; skipping. metadata keys=%s", sorted(meta))
+    continue
+self._run(statement, params)
+```
+
+#### `StarburstManager` (`starburst.py`)
+
+- Capabilities: `kinds=["structured"], query=True, query_language="sql", writable=False`.
+- **`self.schema` → `self.db_schema`** (`starburst.py:67`), with its three readers updated:
+  `starburst.py:111` (`schema=self.db_schema or None` — the *trino* kwarg name is untouched),
+  `starburst.py:116` (log line), `starburst.py:204` (the `source` string). The `schema=` **constructor
+  keyword is unchanged**, so both call sites that pass it
+  (`examples/cli/knowledgebase/openai/starburst/demo.py:22`, `.../multi/demo.py:99`) are untouched, and
+  `manager.schema` now resolves to the inherited `schema()` method.
+- `read` → **`query`**, first parameter renamed `query` → `statement`, and the default `limit` moves
+  from **5** to 3. The design's behavioural-change list records only Neo4j's 10 → 3; Starburst's 5 → 3
+  is the second instance — see [Deviations and additions](#deviations-and-additions) D.
+- `write` raises `KnowledgeCapabilityError(self.backend_name, "write")` instead of
+  `NotImplementedError` (`starburst.py:141`).
+- The `[]`-on-failure behavior of `_execute` (`starburst.py:223,227`) is **left as is**. It is a real
+  wart the design's motivation names, but changing it would alter what every existing Starburst
+  deployment's agent sees on a query error, and the design does not ask for it. Noted so it is not
+  mistaken for an omission.
+
+#### `knowledgebase/__init__.py`
+
+Rewritten from a single comment line to the PEP 562 lazy pattern of
+`deployment/aws/__init__.py:13-66` — a `_LAZY_EXPORTS` name → submodule map, `__all__`,
+`__getattr__`/`__dir__`, and a `TYPE_CHECKING`-only mirror block so mypy and IDEs still resolve the
+real types:
+
+| Name | Module |
+|---|---|
+| `KnowledgeBase`, `Record` | `.base` |
+| `KnowledgeBuilder` | `.knowledgebuilder` |
+| `KnowledgeCapabilities`, `KnowledgeMetadata`, `KnowledgeRecord` | `.model` |
+| `KnowledgeError`, `KnowledgeCapabilityError`, `KnowledgePathError` | `.errors` |
+| `DocumentKnowledgeBase` | `.document` |
+| `DocumentStore`, `LocalDocumentStore`, `S3DocumentStore` | `.store` |
+| `OKFManager` | `.okf.manager` |
+| `OKFBundle`, `OKFConcept`, `OKFDiagnostic`, `TrustTier` | `.okf.model` |
+
+This fixes the import documented at `docs/docs/core-concepts/overview.md:353` without making
+`chromadb`/`neo4j`/`trino`/`boto3` eager. `ChromaManager`, `Neo4jManager`, and `StarburstManager` are
+**deliberately not exported** — each pulls an optional SDK at module import, and the existing examples
+import them from their concrete modules. `testing.py` is not exported (it imports `pytest`).
+
+Asserted by test: every name in `__all__` resolves; importing `agentkernel.knowledgebase` and touching
+`KnowledgeBase`/`OKFManager` leaves `chromadb`, `neo4j`, `trino`, and `boto3` out of `sys.modules`.
+
+#### Example — `examples/cli/knowledgebase/openai/okf/`
+
+New, in the shape of its siblings (`build.sh`, `demo.py`, `demo_test.py`, `__init__.py`,
+`pyproject.toml`, `README.md`) plus a small checked-in bundle:
+
+```
+okf/
+├── bundle/                     # ~6 concepts, exercising every tolerance rule
+│   ├── index.md                # bundle root: okf_version: "0.2" + a curated listing
+│   ├── log.md
+│   ├── tables/
+│   │   ├── index.md            # a non-root curated listing, honoured by browse()
+│   │   ├── orders.md           # human-reviewed, links to customers.md
+│   │   └── customers.md        # machine-confirmed
+│   ├── datasets/orders_db.md   # unverified, unknown `type`
+│   └── malformed.md            # no frontmatter -> skipped with a diagnostic
+├── demo.py                     # LocalDocumentStore("./bundle") -> OKFManager -> KnowledgeBuilder
+└── demo_test.py                # browse_kb -> fetch_kb -> read_kb against real bundle paths
+```
+
+`demo.py` needs **no** `add_schema()` call — that is the point of `derives_schema=True`, and the
+example demonstrates it. It does register a `semantic_map` for the bundle root so the environment-swap
+story is visible. `pyproject.toml` needs no KB extra (pyyaml is core); it depends on `agentkernel[openai,cli,test]`
+like its siblings.
+
+#### Documentation
+
+| Surface | Change |
+|---|---|
+| `docs/docs/advanced/knowledge-bases.md:15-45` (`### KnowledgeBase`) | the five-operation set replaces the `read`/`write` pair; `KnowledgeCapabilities` and which tool each capability emits; `OKFManager` added to the backend list |
+| same file, `## KnowledgeBuilder and Tools:47` | the three new tools and their gating |
+| same file, new section | the OKF backend, `DocumentStore` local-vs-S3, `from_uri`, `refresh_seconds`/`max_concepts` and the refresh cost |
+| same file, `### Minimal implementation:203-235` | **breaking**: the example subclass declares `capabilities` and calls `super().__init__(capabilities=...)`. As written today it defines no `__init__` at all, so it stops constructing outright — see [Deviations and additions](#deviations-and-additions) E |
+| same file, `### Optional overrides:253-260` | add `_derived_schema()`; note `schema()` now always carries `capabilities` |
+| `docs/docs/core-concepts/overview.md:353` | the documented import starts working; the surrounding bullet list gains the operation set |
+| both pages | the two prompt-visible migrations: `schema()` gaining `"capabilities"`, and `StarburstManager.schema` → `db_schema` |
+
+#### Dev skills
+
+`.agents/skills/ak-dev-new-knowledgebase-integration/SKILL.md` is the one skill whose content the change
+invalidates outright: its step 2 sketch calls `super().__init__()` with no arguments, its step 3
+"Record Contract" predates `KnowledgeMetadata`, its step 4 tells authors to raise `NotImplementedError`
+for a read-only backend, and it has no capability-declaration or `DocumentStore` step.
+`.agents/skills/ak-dev-architecture/SKILL.md`'s Knowledge Bases section (the `KnowledgeBase` member
+list and the four-tool `KnowledgeBuilder` line) and `ak-py/src/agentkernel/skills/ak-add-capabilities/`
+also reference the old surface. Ordering these updates is `plan.md`'s final iteration.
+
+### Security
+
+Three obligations, each landing in exactly one place so no caller can forget it:
+
+- **Containment belongs to the `DocumentStore`**, implemented once as `normalise_relative` and applied
+  by every entrypoint plus the walk's own emitted paths. `DocumentKnowledgeBase` turns a refusal into
+  an error result for the agent, but is never the only place an escape is detected. `..` segments,
+  absolute paths, and symlinks resolving outside `LocalDocumentStore.root` are refused on access and
+  skipped during traversal.
+- **No network fetch of OKF reference fields.** `resource`, `sources[].resource`, and `computation`
+  values that are absolute URLs are returned to the agent as data and never dereferenced by any part of
+  the KB layer — the multimodal hook's stance on remote references
+  (`core/multimodal/hooks.py:41,344`). Asserted by a test that fails if the parser or manager pulls in
+  `urllib`/`httpx`.
+- **Concept body text is untrusted content** authored by whoever produced the bundle. It is returned as
+  data and nothing in the layer acts on instructions found inside it: no body text is ever passed to a
+  store path, an `eval`, a subprocess, or a network call, and `type` values — which producers invent
+  freely — are used only as opaque strings for ranking and schema derivation, never dispatched on.
+  Executing `type: Attested Computation` concepts stays a non-goal; they are read like any other
+  concept.
+
+### Config changes
+
+**None.** No `AKConfig` section is added (design decision 1), no field is renamed, and no `AK_*`
+environment variable gains or loses meaning. YAML files and env vars written before this change behave
+identically after it. Backends stay application-constructed; `DocumentStore.from_uri` keeps
+local-in-dev / S3-in-prod a one-string change that the *application* reads from its own environment.
+
+### Data compatibility
+
+- **Chroma**: records written by the old `write_kb` carry `cypher_query`/`cypher_params` in their stored
+  metadata. They are **not migrated** (design item 5, and an explicit non-goal). They read back exactly
+  as before — the dead keys are inert data, and `format_results` never renders them.
+- **Neo4j**: old-shape records (hand-written or already queued) keep working because `write` falls back
+  to the `cypher_*` spelling.
+- **OKF**: documents this change writes are ordinary v0.2 concept documents, readable by any conformant
+  consumer, including the reference visualizer. Nothing is written outside `write_prefix` unless the
+  caller supplies `metadata["id"]`.
+- No on-disk or in-store format owned by AK changes.
+
+### Behavioural changes
+
+Items 1-13 are `design.md`'s list, restated only where this spec fixes a detail; 14-16 are new and are
+flagged for design review. Each needs a test.
+
+1. `KnowledgeBase.read` becomes concrete, routing on `capabilities.query`. `ChromaManager.read` →
+   `search`; `Neo4jManager.read` and `StarburstManager.read` → `query`. A third-party subclass
+   overriding `read()` keeps winning.
+2. `StarburstManager.write` raises `KnowledgeCapabilityError`, not `NotImplementedError`. The new type
+   does not subclass the old one; in-tree no caller catches it.
+3. `schema()` no longer raises when `add_schema()` was skipped **and** `_derived_schema()` is non-empty.
+   All three existing backends declare `derives_schema=False` and return `{}`, so their behavior is
+   unchanged.
+4. `schema()` output gains `"capabilities"` — additive, and prompt-visible through `get_schemas`.
+5. `write_kb` no longer writes `cypher_query`/`cypher_params`. Agent-issued Neo4j writes are unaffected
+   (item 12); already-stored Chroma metadata is not migrated.
+6. `get_schemas` degrades per backend instead of failing the whole call.
+7. `build()` returns up to seven callables rather than four.
+8. `agentkernel.knowledgebase` exports names for the first time; the documented import starts working.
+9. `StarburstManager`'s Trino schema name moves to `self.db_schema`. The `schema=` keyword is unchanged.
+   `get_schemas` starts returning a real schema for Starburst instead of raising `TypeError` — a
+   prompt-visible change for **every** Starburst deployment.
+10. `format_results` prefixes `[<id>]` for backends declaring `fetch`. No existing backend does, so
+    in-tree output is byte-identical.
+11. `Neo4jManager.query` defaults to `limit=3` instead of `limit=10`. `read_kb` always passes `limit`,
+    so only direct callers see it.
+12. `Neo4jManager.write` reads the generic keys with the `cypher_*` fallback and skips a record carrying
+    neither, with a warning.
+13. `KnowledgeBase.__init__` requires `capabilities` (`name` optional) — the only signature in this
+    change that is not backward compatible. **Its reach is wider than the design states**: it breaks
+    not only a subclass that calls `super().__init__()` with no arguments, but also one that defines no
+    `__init__` at all (it inherits the new required parameter, so `MyBackend()` raises `TypeError`).
+    The documented example at `docs/docs/advanced/knowledge-bases.md:212` is exactly that shape.
+14. **`StarburstManager.query` defaults to `limit=3` instead of `limit=5`** (`starburst.py:151`), the
+    same class of change as item 11 and not listed in the design.
+15. **`query()`'s first parameter is named `statement`, not `query`** — the base signature the design
+    fixes. A caller using `neo4j.read(query="…")` or `starburst.read(query="…")` **by keyword** keeps
+    working through the inherited `read()`, but a caller switching to `query(query="…")` gets a
+    `TypeError`. In-tree there are no keyword callers of either.
+16. **`read` and `write` are no longer abstract.** Additive for existing subclasses; a new subclass may
+    now omit both, and the required abstract surface shrinks to `backend_name`, `connect`,
+    `get_description`.
+
+**Non-changes, to be asserted:**
+
+- `Record` stays `Mapping[str, Any]` and stays the annotation on every signature; `KnowledgeMetadata`
+  and `KnowledgeRecord` appear in no signature.
+- `read`/`write` signatures, including `**kwargs`, which every new operation also carries; `read()`
+  forwards `**kwargs` unchanged to the primitive it delegates to.
+- The four existing tool names and signatures, and every existing tool error/validation string.
+- `KnowledgeBuilder.__init__`'s `(backends, semantic_map)` signature and its duplicate/empty
+  `backend_name` `ValueError`s.
+- `add_schema` / `close`, and `format_results`' output for every backend declaring `fetch=False`.
+- The `schema=` keyword on `StarburstManager.__init__`; the `ValueError` text in `schema()`.
+- No `AKConfig` section, no framework-adapter change, no new optional extra.
+- Every existing example under `examples/cli/knowledgebase/openai/` runs unmodified.
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| Undeclared operation called on a backend | `KnowledgeCapabilityError`, caught at the tool boundary and returned as an actionable string naming the backends that do declare it |
+| Path escaping a store's namespace (agent path, concept link, or walk entry) | `KnowledgePathError` from the store; the walk skips the entry with a `path_escape` diagnostic; `fetch`/`browse` drop that path with a logged warning; `write` refuses the record |
+| Missing or unreadable document | `read_bytes` → `FileNotFoundError` → empty result plus a logged warning. Never a traversal, never a raise into the framework |
+| Malformed concept | skipped with a diagnostic; the bundle still loads (conformance requirement) |
+| Missing store configuration (unreadable root) | `ValueError` at construction, matching `starburst.py:102` |
+| Missing `boto3` for `s3://` | `ImportError` naming the `aws` extra, via `require_extra` |
+| Unresolvable `from_uri` value | `AKConfigError` |
+| Manifest refresh failure | logged at `warning`; the previous manifest continues to serve; the clock resets so one attempt is made per interval |
+| Initial manifest load failure | propagates out of `connect()` |
+| Backend declaring `query=True` with no `query_language` (or the reverse), or declaring nothing at all | `ValueError` at construction, naming the backend |
+| `write` on a non-writable backend or store | `KnowledgeCapabilityError` before any I/O |
+
+Exception scope, stated because the design does not: the only broad `except Exception` handlers are the
+pre-existing ones in the tool bodies (which must return strings) and the manifest-refresh guard (which
+must not let a transient store failure kill a serving pod). Everywhere else the caught types are
+enumerated: `FileNotFoundError`, `yaml.YAMLError`, `ClientError`, `KnowledgePathError`.
+
+## Testing
+
+Run with `cd ak-py && uv run pytest`. CI installs `uv sync --all-extras` (`ak-py/build.sh:9`), so
+`chromadb`, `neo4j`, `trino`, and `boto3` are importable in the test environment — their *clients* are
+still mocked; no test touches a live service.
+
+**No existing test file changes.** There are no tests referencing the knowledge-base tier today
+(verified by grep over `ak-py/tests/`), so this change moves **no** patch targets — it only adds files.
+
+| New file | Asserts |
+|---|---|
+| `tests/test_knowledgebase_model.py` | `KnowledgeCapabilities` defaults and `model_dump()` shape; `validate_capabilities` — reachability, both directions of query coherence, the reachability check reported first, each message naming the given subject; the class-name fallback when `name` is omitted; that constructing a `KnowledgeCapabilities` alone never validates |
+| `tests/test_knowledgebase_base.py` | `read()` routes to `query()` when `capabilities.query` and to `search()` otherwise, forwarding `**kwargs` and `limit`; a subclass overriding `read()` still wins; undeclared operations raise `KnowledgeCapabilityError` naming backend and operation; `schema()` precedence (`backend` overridable, `capabilities` not, derived beaten by `add_schema`), the relaxed guard, and the byte-identical `ValueError`; `format_results` gating (fetch off, fetch on with/without a usable `id`) |
+| `tests/test_knowledgebase_builder.py` | **the riskiest consumer.** Tool-list gating for every combination (vector-only → exactly the four; fetch-only; browse-only; search+query → `search_kb`); tool order; capability-mismatch strings; `write_kb` emitting `query`/`params` and **not** `cypher_*`; `get_schemas` degrading per backend; semantic-map resolution on `search_kb` queries, `fetch_kb` ids (per segment) and `browse_kb` paths; `fetch_kb` id splitting/stripping/empty-dropping; a backend missing `capabilities` warning instead of raising |
+| `tests/test_knowledgebase_stores.py` | `DocumentStoreContract` over `LocalDocumentStore` (real `tmp_path`) and `S3DocumentStore` (fake boto3 client, including a paginated `list_objects_v2` and `NoSuchKey` → `FileNotFoundError`); containment matrix (`..`, absolute, backslash, normalising escapes) on every entrypoint; a symlink out of `root` skipped by `list()` and refused on read; global lexicographic ordering including the `a/z.md` vs `ab/b.md` case; `writable` probing vs declaration; `write_bytes` refused on a read-only store; `read_prefix_bytes` default vs the S3 ranged GET; `from_uri`'s five branches including `python:` and an `AKConfigError` scheme |
+| `tests/test_knowledgebase_okf_parser.py` | frontmatter splitting (missing open/close, non-mapping YAML); `type` required, unknown `type` kept; unknown keys → `extra`; bare `verified` → one-element list; scalar `tags`; the three trust tiers; staleness against an injected `now`, and the unparseable case; link extraction in both forms plus relative resolution, escapes dropped, absolute URLs ignored, non-`.md` ignored; **v0.2-only**: a v0.1 `timestamp` lands in `extra` and a body `# Citations` list stays body text; every diagnostic code is reachable; no `urllib`/`httpx` import on any path |
+| `tests/test_knowledgebase_okf_manager.py` | capabilities built from the store (writable folding both ways); `_derived_schema()` keys against a known bundle; `schema()` working with no `add_schema()`; search ranking — weights, presence-not-frequency, `(-score, path)` determinism across two managers, zero-score exclusion; `fetch` order/dedup/unknown-id omission and links present only here; `browse` index-vs-derived at root **and** at `tables/`, `limit` truncation, unknown directory; `write` — synthesised vs supplied id, comma refusal at both ends, fixed key order and byte-identical re-render, `generated` stamp, producer default and override; **write-through visibility with `refresh_seconds=None`** (proving it is not a refresh); refresh timing with a monkeypatched `time.monotonic`; a failed refresh serving the stale manifest and resetting the clock; `reload()`; **one walk under two concurrent boundary-crossing callers** (a `threading.Barrier` plus a walk counter); `max_concepts` truncation keeping a lexicographic prefix with a `truncated` diagnostic; nothing filtered on trust or staleness; diagnostics surfaced through `get_description()` |
+| `tests/test_knowledgebase_okf_envelope.py` | the declared scale. A session-scoped fixture generates a 10,000-concept bundle in `tmp_path`; the test asserts the walk keeps all 10,000 and that `tracemalloc` allocations attributable to the manifest build stay under 50 MB, measured as the sum of `size_diff` over a `snapshot_after.compare_to(snapshot_before, "filename")` around `_walk()` — **not** process RSS, which moves with the interpreter and the allocator's retained arenas |
+| `tests/test_knowledgebase_contract.py` | `KnowledgeBaseContract` run against `FakeKnowledgeBase` (four capability shapes), `OKFManager` over a real local bundle, and the three existing backends with mocked clients — `monkeypatch` on `chromadb.PersistentClient`, `neo4j.GraphDatabase.driver`, and `trino.dbapi.connect` (plus host/user/password constructor args for Starburst) |
+| `tests/test_knowledgebase_exports.py` | every `__all__` name resolves; `chromadb`/`neo4j`/`trino`/`boto3` stay out of `sys.modules` after importing the package and touching `KnowledgeBase`/`OKFManager`; `testing.py` is not exported; the `overview.md:353` import works verbatim |
+| `examples/cli/knowledgebase/openai/okf/demo_test.py` | the example-level convention (`Test("demo.py")`, ordered cases): the agent browses the bundle, fetches a concept by its real path, and answers from it |
+
+`knowledgebase/testing.py` ships two reusable suites in the `SandboxProviderContract`
+(`sandbox/testing.py:130`) / `QueueTransportContract` shape — subclass, override one fixture, and
+pytest collects the contract against your backend. Neither class name is prefixed `Test`.
+
+`KnowledgeBaseContract` asserts, for any backend: declared capabilities match implemented operations
+(each declared one returns a list; each undeclared one raises `KnowledgeCapabilityError`); `schema()`
+is callable and returns a `Mapping` — the regression guard for the `StarburstManager` attribute/method
+collision; records carry a non-empty string `metadata["id"]` **containing no `,`** when `fetch` is
+declared, generalised as "a backend whose ids cannot be comma-free must not declare `fetch`"; unknown
+keys round-trip at **both** the record and the metadata level; every operation accepts `**kwargs`;
+both construction-time invariants are enforced and each error names the backend without reading
+`backend_name`; `read()` routes on `capabilities.query`; and `derives_schema=True` implies a non-empty
+`_derived_schema()`.
+
+`DocumentStoreContract` asserts: round-trip `write_bytes`/`read_bytes`/`exists`; `FileNotFoundError` on
+a missing path; `list()` global lexicographic order and prefix filtering; containment refusal on every
+entrypoint; `read_prefix_bytes` returning a prefix of `read_bytes`; and `write_bytes` raising when
+`writable` is `False`.
+
+## Deviations and additions
+
+Nothing below changes the design's shape; each is a detail the design left open or a claim it scoped
+too narrowly. Flagged for design re-review per the staged process rather than absorbed silently.
+
+| | Item | Why |
+|---|---|---|
+| A | **`KnowledgePathError`**, a third error type in `errors.py` | The design has the store refuse an escaping path and `DocumentKnowledgeBase` map the refusal to an agent-facing result. That mapping needs a type to catch; `ValueError` would also swallow unrelated failures |
+| B | **`write_prefix` and id synthesis** on `OKFManager.write` | `write_kb`'s signature carries no id and the design freezes it as a non-change, so an agent-issued OKF write has no way to name a bundle path. Without synthesis the design's write path is unreachable from the agent surface |
+| C | **`DocumentStore.read_prefix_bytes`**, a sixth method with a default implementation | Makes the eager frontmatter pass affordable over S3 (a bounded ranged GET per concept instead of a full object). Defaulted, so a bring-your-own store need not implement it |
+| D | **Two behavioural changes the design's list omits** (items 14-15): `StarburstManager`'s default `limit` 5 → 3, and `query()`'s first parameter named `statement` | The design's item 11 quantifies over Neo4j only; `starburst.py:151` is a second instance, and the parameter rename is implied by the base signature the design fixes |
+| E | **Migration item 13's reach** | The design scopes it to "a subclass calling `super().__init__()` with no arguments". A subclass defining no `__init__` at all also breaks — which is exactly the shape of the documented example at `docs/docs/advanced/knowledge-bases.md:212` |
+| F | **The manifest retains a bounded body token index, not bodies** | "Frontmatter parsed eagerly, bodies read lazily" and "search ranks over body text" cannot both hold literally. A bounded token set per concept satisfies both intents and keeps the ~50 MB envelope; full bodies (and therefore complete `links`) are read only by `fetch`, which is how the design already describes traversal |
+| G | **`capabilities` is not overridable via `add_schema()`**, and `search_mode` is deliberately not bidirectional with `search` | Two precedence/scope questions the design leaves open; both resolved in the direction that keeps the declaration honest |
+
+## Next stage
+
+`plan.md` (stage 3) orders this into iterations and is not written until this document is reviewed.

--- a/docs/specs/553-okf-knowledge-bases/spec.md
+++ b/docs/specs/553-okf-knowledge-bases/spec.md
@@ -736,15 +736,30 @@ The four existing tools keep their names and signatures. Three are added, each g
   `limit` moves from 10 to 3.
 - `write` reads `metadata["query"]` first and falls back to `metadata["cypher_query"]` (same for
   `params`/`cypher_params`), and **skips a record carrying neither** with a logged warning instead of
-  calling `_run(None, {})`:
+  calling `_run(None, {})`. The skips are then **reported by raising `KnowledgeError` once the batch is
+  through**: the writable records still land, but a write that stored nothing is no longer reported to
+  the agent as a success — see behavioural change 17 and
+  [Deviations and additions](#deviations-and-additions) H.
 
 ```python
-statement = meta.get("query") or meta.get("cypher_query")
-params = meta.get("params") or meta.get("cypher_params") or {}
-if not statement:
-    log.warning("[neo4j.write] record carries no query; skipping. metadata keys=%s", sorted(meta))
-    continue
-self._run(statement, params)
+stored, skipped = 0, 0
+for record in records:
+    meta = dict(record.get("metadata", {}))
+    statement = meta.get("query") or meta.get("cypher_query")
+    params = meta.get("params") or meta.get("cypher_params") or {}
+    if not statement:
+        log.warning("[neo4j.write] record carries no query; skipping. metadata keys=%s", sorted(meta))
+        skipped += 1
+        continue
+    self._run(statement, params)
+    stored += 1
+
+if skipped:
+    raise KnowledgeError(
+        f"[KB][{self.backend_name}] {skipped} of {stored + skipped} record(s) carried no Cypher "
+        f"and were not stored ({stored} stored). A Neo4j write needs the statement in "
+        "metadata['query']."
+    )
 ```
 
 #### `StarburstManager` (`starburst.py`)
@@ -881,7 +896,7 @@ local-in-dev / S3-in-prod a one-string change that the *application* reads from 
 
 ### Behavioural changes
 
-Items 1-13 are `design.md`'s list, restated only where this spec fixes a detail; 14-16 are new and are
+Items 1-13 are `design.md`'s list, restated only where this spec fixes a detail; 14-17 are new and are
 flagged for design review. Each needs a test.
 
 1. `KnowledgeBase.read` becomes concrete, routing on `capabilities.query`. `ChromaManager.read` →
@@ -906,7 +921,8 @@ flagged for design review. Each needs a test.
 11. `Neo4jManager.query` defaults to `limit=3` instead of `limit=10`. `read_kb` always passes `limit`,
     so only direct callers see it.
 12. `Neo4jManager.write` reads the generic keys with the `cypher_*` fallback and skips a record carrying
-    neither, with a warning.
+    neither, with a warning. The batch then **raises `KnowledgeError`** naming what was stored and what
+    was not — see item 17.
 13. `KnowledgeBase.__init__` requires `capabilities` (`name` optional) — the only signature in this
     change that is not backward compatible. **Its reach is wider than the design states**: it breaks
     not only a subclass that calls `super().__init__()` with no arguments, but also one that defines no
@@ -921,6 +937,14 @@ flagged for design review. Each needs a test.
 16. **`read` and `write` are no longer abstract.** Additive for existing subclasses; a new subclass may
     now omit both, and the required abstract surface shrinks to `backend_name`, `connect`,
     `get_description`.
+17. **A text-only Neo4j `write_kb` now reports a failure.** `Neo4jManager.write` raises
+    `KnowledgeError` after the batch when any record carried no Cypher, so
+    `write_kb("neo4j", text="…")` with no query surfaces "Failed to write…" rather than "Stored
+    successfully" for a write that stored nothing. Prompt-visible, and deliberate: on `develop` such a
+    write also failed, but only because `_run(None, {})` happened to error — item 12's skip would have
+    turned that failure into a silent success. Pinned by
+    `test_the_skip_report_names_what_was_stored_and_what_was_not`; see
+    [Deviations and additions](#deviations-and-additions) H.
 
 **Non-changes, to be asserted:**
 
@@ -1012,6 +1036,7 @@ too narrowly. Flagged for design re-review per the staged process rather than ab
 | E | **Migration item 13's reach** | The design scopes it to "a subclass calling `super().__init__()` with no arguments". A subclass defining no `__init__` at all also breaks — which is exactly the shape of the documented example at `docs/docs/advanced/knowledge-bases.md:212` |
 | F | **The manifest retains a bounded body token index, not bodies** | "Frontmatter parsed eagerly, bodies read lazily" and "search ranks over body text" cannot both hold literally. A bounded token set per concept satisfies both intents and keeps the ~50 MB envelope; full bodies (and therefore complete `links`) are read only by `fetch`, which is how the design already describes traversal |
 | G | **`capabilities` is not overridable via `add_schema()`**, and `search_mode` is deliberately not bidirectional with `search` | Two precedence/scope questions the design leaves open; both resolved in the direction that keeps the declaration honest |
+| H | **`Neo4jManager.write` raises `KnowledgeError` after a batch that skipped records** (item 17), rather than only logging the skip | The design has the skip keep the rest of the batch running but leaves the agent-facing result unstated. Logging alone would report a write that stored nothing as a success — strictly worse than pre-#553, where `_run(None, {})` at least errored. Raising after the loop keeps both intents: the writable records land, and the tool layer reports the truth |
 
 ## Next stage
 

--- a/examples/api/openai/app.py
+++ b/examples/api/openai/app.py
@@ -23,12 +23,14 @@ customer_support_agent = Agent(
     "customer itself and mimic the conversation. Ask questions one by one and gather answers and show "
     "the summary once the conversation is over.",
     tools=[fetch_customer_activity],
+    model="gpt-4.1-mini"
 )
 
 triage_agent = Agent(
     name="triage",
     instructions="You determine which agent to use based on the user's question.",
     handoffs=[general_agent, customer_support_agent],
+    model="gpt-4.1-mini"
 )
 
 # Optional custom route to add your own endpoints

--- a/examples/api/openai/app.py
+++ b/examples/api/openai/app.py
@@ -23,14 +23,14 @@ customer_support_agent = Agent(
     "customer itself and mimic the conversation. Ask questions one by one and gather answers and show "
     "the summary once the conversation is over.",
     tools=[fetch_customer_activity],
-    model="gpt-4.1-mini"
+    model="gpt-4.1-mini",
 )
 
 triage_agent = Agent(
     name="triage",
     instructions="You determine which agent to use based on the user's question.",
     handoffs=[general_agent, customer_support_agent],
-    model="gpt-4.1-mini"
+    model="gpt-4.1-mini",
 )
 
 # Optional custom route to add your own endpoints

--- a/examples/api/openai/uv.lock
+++ b/examples/api/openai/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [[package]]
 name = "agentkernel"
 version = "0.9.0"
-source = { registry = "../../../ak-py/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
@@ -18,9 +18,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "singleton-type" },
 ]
-sdist = { path = "agentkernel-0.9.0.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/d6/b4c253110afcee7c5190e5f47aded5bb20c714fb299983dcfdc569383caf/agentkernel-0.9.0.tar.gz", hash = "sha256:394c33e46da7eb591effff92d530b9246a5065b02970888bce54c474d3e8cf16", size = 487819, upload-time = "2026-09-02T10:22:41.36Z" }
 wheels = [
-    { path = "agentkernel-0.9.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/488e8e932d071ed2f00788c4017db69e83d34a527a71d226491c6e14911a/agentkernel-0.9.0-py3-none-any.whl", hash = "sha256:772863c829e7814be48f1975b0bc8e17e1fb3ad9d3356d8e4d77afe61bd23e54", size = 653309, upload-time = "2026-09-02T10:22:39.274Z" },
 ]
 
 [package.optional-dependencies]

--- a/examples/cli/adk/uv.lock
+++ b/examples/cli/adk/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [[package]]
 name = "agentkernel"
 version = "0.9.0"
-source = { registry = "../../../ak-py/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
@@ -18,9 +18,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "singleton-type" },
 ]
-sdist = { path = "agentkernel-0.9.0.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/d6/b4c253110afcee7c5190e5f47aded5bb20c714fb299983dcfdc569383caf/agentkernel-0.9.0.tar.gz", hash = "sha256:394c33e46da7eb591effff92d530b9246a5065b02970888bce54c474d3e8cf16", size = 487819, upload-time = "2026-09-02T10:22:41.36Z" }
 wheels = [
-    { path = "agentkernel-0.9.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/488e8e932d071ed2f00788c4017db69e83d34a527a71d226491c6e14911a/agentkernel-0.9.0-py3-none-any.whl", hash = "sha256:772863c829e7814be48f1975b0bc8e17e1fb3ad9d3356d8e4d77afe61bd23e54", size = 653309, upload-time = "2026-09-02T10:22:39.274Z" },
 ]
 
 [package.optional-dependencies]

--- a/examples/cli/guardrail/bedrock/uv.lock
+++ b/examples/cli/guardrail/bedrock/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 [[package]]
 name = "agentkernel"
 version = "0.9.0"
-source = { registry = "../../../../ak-py/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
@@ -19,9 +19,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "singleton-type" },
 ]
-sdist = { path = "agentkernel-0.9.0.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/d6/b4c253110afcee7c5190e5f47aded5bb20c714fb299983dcfdc569383caf/agentkernel-0.9.0.tar.gz", hash = "sha256:394c33e46da7eb591effff92d530b9246a5065b02970888bce54c474d3e8cf16", size = 487819, upload-time = "2026-09-02T10:22:41.36Z" }
 wheels = [
-    { path = "agentkernel-0.9.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/488e8e932d071ed2f00788c4017db69e83d34a527a71d226491c6e14911a/agentkernel-0.9.0-py3-none-any.whl", hash = "sha256:772863c829e7814be48f1975b0bc8e17e1fb3ad9d3356d8e4d77afe61bd23e54", size = 653309, upload-time = "2026-09-02T10:22:39.274Z" },
 ]
 
 [package.optional-dependencies]

--- a/examples/cli/guardrail/openai/uv.lock
+++ b/examples/cli/guardrail/openai/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 [[package]]
 name = "agentkernel"
 version = "0.9.0"
-source = { registry = "../../../../ak-py/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
@@ -22,9 +22,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "singleton-type" },
 ]
-sdist = { path = "agentkernel-0.9.0.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/d6/b4c253110afcee7c5190e5f47aded5bb20c714fb299983dcfdc569383caf/agentkernel-0.9.0.tar.gz", hash = "sha256:394c33e46da7eb591effff92d530b9246a5065b02970888bce54c474d3e8cf16", size = 487819, upload-time = "2026-09-02T10:22:41.36Z" }
 wheels = [
-    { path = "agentkernel-0.9.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/488e8e932d071ed2f00788c4017db69e83d34a527a71d226491c6e14911a/agentkernel-0.9.0-py3-none-any.whl", hash = "sha256:772863c829e7814be48f1975b0bc8e17e1fb3ad9d3356d8e4d77afe61bd23e54", size = 653309, upload-time = "2026-09-02T10:22:39.274Z" },
 ]
 
 [package.optional-dependencies]

--- a/examples/cli/langgraph/uv.lock
+++ b/examples/cli/langgraph/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 [[package]]
 name = "agentkernel"
 version = "0.9.0"
-source = { registry = "../../../ak-py/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
@@ -17,9 +17,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "singleton-type" },
 ]
-sdist = { path = "agentkernel-0.9.0.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/d6/b4c253110afcee7c5190e5f47aded5bb20c714fb299983dcfdc569383caf/agentkernel-0.9.0.tar.gz", hash = "sha256:394c33e46da7eb591effff92d530b9246a5065b02970888bce54c474d3e8cf16", size = 487819, upload-time = "2026-09-02T10:22:41.36Z" }
 wheels = [
-    { path = "agentkernel-0.9.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/488e8e932d071ed2f00788c4017db69e83d34a527a71d226491c6e14911a/agentkernel-0.9.0-py3-none-any.whl", hash = "sha256:772863c829e7814be48f1975b0bc8e17e1fb3ad9d3356d8e4d77afe61bd23e54", size = 653309, upload-time = "2026-09-02T10:22:39.274Z" },
 ]
 
 [package.optional-dependencies]

--- a/examples/cli/langgraph_context/uv.lock
+++ b/examples/cli/langgraph_context/uv.lock
@@ -19,7 +19,7 @@ resolution-markers = [
 [[package]]
 name = "agentkernel"
 version = "0.9.0"
-source = { registry = "../../../ak-py/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "pydantic" },
@@ -27,9 +27,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "singleton-type" },
 ]
-sdist = { path = "agentkernel-0.9.0.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/d6/b4c253110afcee7c5190e5f47aded5bb20c714fb299983dcfdc569383caf/agentkernel-0.9.0.tar.gz", hash = "sha256:394c33e46da7eb591effff92d530b9246a5065b02970888bce54c474d3e8cf16", size = 487819, upload-time = "2026-09-02T10:22:41.36Z" }
 wheels = [
-    { path = "agentkernel-0.9.0-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/488e8e932d071ed2f00788c4017db69e83d34a527a71d226491c6e14911a/agentkernel-0.9.0-py3-none-any.whl", hash = "sha256:772863c829e7814be48f1975b0bc8e17e1fb3ad9d3356d8e4d77afe61bd23e54", size = 653309, upload-time = "2026-09-02T10:22:39.274Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Description


`KnowledgeCapabilities`, the reshaped `KnowledgeBase` ABC, the three existing backends migrated onto
it, and the capability-gated `KnowledgeBuilder` tool surface.


## Type of Change
<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test update
- [ ] CI/CD update
- [ ] Other (please describe):

Breaking for **custom** `KnowledgeBase` subclasses only — see *Breaking changes* below. The three
bundled backends and every existing example are unchanged at the call site.

## Changes Made

### Capability model (new) — `knowledgebase/model.py`, `knowledgebase/errors.py`

- `KnowledgeCapabilities`: nine fields declaring what a backend actually supports — `kinds`,
  `search` / `search_mode`, `query` / `query_language`, `fetch`, `browse`, `writable`,
  `derives_schema`. Deliberately free of cross-field validators; the invariants are enforced where the
  backend name is known.
- `KnowledgeMetadata` / `KnowledgeRecord`: `total=False` `TypedDict`s documenting the record shape that
  travels between backends and tools. Documentation-only — `Record = Mapping[str, Any]` stays the
  annotation on every signature.
- `KnowledgeError` → `KnowledgeCapabilityError`, `KnowledgePathError`. `KnowledgeCapabilityError`
  follows the `sandbox/errors.py` shape and is deliberately **not** a `NotImplementedError`, so a
  declaration mismatch is distinguishable from an unimplemented abstract method.


## Testing
<!-- Describe the testing you have performed -->

- [x] Unit tests pass locally
- [x] Integration tests pass locally
- [x] Manual testing completed
- [x] New tests added for changes

## Checklist
<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (spec docs land here; the
      user-facing docs and skills sync is iteration 9)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
