### PR TITLE
docs: correct two wrong API signatures in documentation examples

### DIFF
--- a/docs/docs/api/rest-api.md
+++ b/docs/docs/api/rest-api.md
@@ -333,7 +333,7 @@ class CustomRESTRequestHandler(AgentRESTRequestHandler):
         return router
 
 if __name__ == "__main__":
-    RESTAPI.run(handler=CustomRESTRequestHandler())
+    RESTAPI.run([CustomRESTRequestHandler()])
 ```
 
 

--- a/docs/docs/integrations/hooks.md
+++ b/docs/docs/integrations/hooks.md
@@ -375,8 +375,8 @@ class GuardRailHook(PreHook):
             if keyword in prompt_lower:
                 # Halt execution and return rejection message
                 return AgentReplyText(
-                    text=f"I cannot assist with requests related to '{keyword}'. "
-                         "Please ask a different question."
+                    response=f"I cannot assist with requests related to '{keyword}'. "
+                             "Please ask a different question."
                 )
         
         # Prompt is safe - continue with execution
@@ -444,8 +444,8 @@ class ModerationHook(PostHook):
         # Check reply for inappropriate content
         if self._contains_sensitive_info(reply_text):
             return AgentReplyText(
-                text="I apologize, but I cannot provide that information. "
-                     "Please rephrase your question."
+                response="I apologize, but I cannot provide that information. "
+                         "Please rephrase your question."
             )
         
         return agent_reply

--- a/docs/docs/integrations/slack.md
+++ b/docs/docs/integrations/slack.md
@@ -115,7 +115,7 @@ OpenAIModule([general_agent])
 # Create and run the server with Slack handler
 if __name__ == "__main__":
     handler = AgentSlackRequestHandler()
-    RESTAPI.run(handler=handler)
+    RESTAPI.run([handler])
 ```
 
 ## Configuration Options

--- a/docs/docs/integrations/whatsapp.md
+++ b/docs/docs/integrations/whatsapp.md
@@ -114,7 +114,7 @@ OpenAIModule([general_agent])
 # Create and run the server with WhatsApp handler
 if __name__ == "__main__":
     handler = AgentWhatsAppRequestHandler()
-    RESTAPI.run(handler=handler)
+    RESTAPI.run([handler])
 ```
 
 ## Configuration Options


### PR DESCRIPTION
## Description

Two API signatures in the documentation examples don't match the implementation. Both appear in copy-paste starting points, so following them fails — one loudly, one silently.

**1. `RESTAPI.run(handler=...)` → `RESTAPI.run([handler])`** — 3 occurrences

The signature is `def run(cls, handlers: list[RESTRequestHandler] = None)` (`ak-py/src/agentkernel/api/http.py:90`). There is no `handler` parameter, so the keyword form raises `TypeError` immediately.

The corrected form already appears in seven other pages — `integrations/instagram.md`, `integrations/messenger.md`, `integrations/overview.md`, `advanced/threads.md`, `api/agui-server.md`, `integrations/agui.md`, `deployment/aws-containerized.md` — so this brings the remaining three in line rather than introducing a new convention.

**2. `AgentReplyText(text=...)` → `AgentReplyText(response=...)`** — 2 occurrences

The field is `response` (`ak-py/src/agentkernel/core/model.py:102`); `AgentReplyText` has no `text` field. This one fails **silently**, because pydantic discards the unknown keyword rather than raising:

```python
>>> r = AgentReplyText(text='I cannot assist with that.')   # no error
>>> r.response
''
>>> str(r)
''
```
Both affected examples are in integrations/hooks.md: a PreHook guardrail that halts execution, and a PostHook that replaces sensitive content. Copied as written, each still halts or replaces as intended but delivers an empty message, with nothing in the logs to point back at the docs.

## Type of Change

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x]  Documentation update
- [ ]  Refactoring (no functional changes)
- [ ]  Performance improvement
- [ ]  Test update
- [ ]  CI/CD update
- [ ]  Other (please describe):

## Related Issues
No existing issue — both found while building an agent against these guides.

## Changes Made
File | Line | Change
-- | -- | --
docs/docs/api/rest-api.md | 336 | RESTAPI.run(handler=CustomRESTRequestHandler()) → RESTAPI.run([CustomRESTRequestHandler()])
docs/docs/integrations/slack.md | 118 | RESTAPI.run(handler=handler) → RESTAPI.run([handler])
docs/docs/integrations/whatsapp.md | 117 | RESTAPI.run(handler=handler) → RESTAPI.run([handler])
docs/docs/integrations/hooks.md | 378 | text= → response= (PreHook guardrail example)
docs/docs/integrations/hooks.md | 447 | text= → response= (PostHook moderation example)

4 files, 7 insertions, 7 deletions. Documentation only — no source, no config, no CI. docs/versioned_docs/ is untouched, as those are frozen release snapshots.

## Testing

- [ ]  Unit tests pass locally
- [ ]  Integration tests pass locally
- [x]  Manual testing completed
- [ ]  New tests added for changes

Both corrected forms were verified against the installed package rather than by reading:

- RESTAPI.run — confirmed the parameter is handlers, typed list[RESTRequestHandler].
- AgentReplyText — confirmed response is the output field and that text= is silently discarded (transcript in the description).

Unit tests are unticked because this PR changes no code and executes no code path; the ak-py suite is unaffected in either direction.

## Checklist

- [x]  My code follows the project's style guidelines
- [x]  I have performed a self-review of my code
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [ ]  I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [ ]  Any dependent changes have been merged and published

Code comments and new tests don't apply to a documentation-only change.

## Screenshots (if applicable)
N/A.

## Additional Notes
Two commits, one per signature, so either can be reverted independently:

- docs: correct RESTAPI.run signature in integration and REST API guides
- docs: correct AgentReplyText field name in execution hooks guide

The AgentReplyText fix is the more valuable of the two. Because pydantic ignores the
unknown keyword instead of raising, the example is wrong in a way that produces a blank reply rather than a traceback — which is hard to trace back to the documentation.